### PR TITLE
Gadget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ go.work.sum
 .env
 
 .vscode
+.idea

--- a/app/backend/component/drawdata/gadget.go
+++ b/app/backend/component/drawdata/gadget.go
@@ -7,6 +7,6 @@ type Gadget struct {
 	Layer      int           `json:"layer"`
 	Height     int           `json:"height"`
 	Width      int           `json:"width"`
-	Color      int           `json:"color"`
+	Color      string        `json:"color"`
 	Attributes [][]Attribute `json:"attributes"`
 }

--- a/app/backend/component/drawdata/gadget.go
+++ b/app/backend/component/drawdata/gadget.go
@@ -7,6 +7,6 @@ type Gadget struct {
 	Layer      int           `json:"layer"`
 	Height     int           `json:"height"`
 	Width      int           `json:"width"`
-	Color      string        `json:"color"`
+	Color      int           `json:"color"`
 	Attributes [][]Attribute `json:"attributes"`
 }

--- a/app/backend/component/drawdata/gadget.go
+++ b/app/backend/component/drawdata/gadget.go
@@ -10,3 +10,6 @@ type Gadget struct {
 	Color      int           `json:"color"`
 	Attributes [][]Attribute `json:"attributes"`
 }
+
+// a default gadget color (grey)
+const DefaultGadgetColor = 0x808080

--- a/app/backend/component/gadget.go
+++ b/app/backend/component/gadget.go
@@ -15,7 +15,7 @@ const (
 )
 
 // a default gadget color (grey)
-const defaultGadgetColor = "#0x808080"
+const defaultGadgetColor = 0x808080
 
 type Gadget struct {
 	gadgetType       GadgetType

--- a/app/backend/component/gadget.go
+++ b/app/backend/component/gadget.go
@@ -10,8 +10,8 @@ import (
 type GadgetType int
 
 const (
-	Class         GadgetType = 1 << iota // 0x01
-	supportedType            = Class
+	Class               GadgetType = 1 << iota // 0x01
+	supportedGadgetType            = Class
 )
 
 type Gadget struct {
@@ -76,7 +76,7 @@ func (g *Gadget) updateDrawData() duerror.DUError {
 	g.drawData.Layer = g.layer
 	g.drawData.Height = height
 	g.drawData.Width = width
-	g.drawData.Color = utils.ToHex(g.color)
+	g.drawData.Color = g.color.ToHex()
 	g.drawData.Attributes = atts
 
 	if g.updateParentDraw == nil {
@@ -94,6 +94,21 @@ func (g *Gadget) RegisterUpdateParentDraw(update func() duerror.DUError) duerror
 gadget func
 */
 
+// point getter
+func (g *Gadget) GetPoint() utils.Point {
+	return g.point
+}
+
+// point setter
+func (g *Gadget) SetPoint(point utils.Point) duerror.DUError {
+	g.point = point
+	err := g.updateDrawData()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func (g *Gadget) getBounds() (utils.Point, utils.Point, duerror.DUError) {
 	//TODO: calculate the Bottom-Right point (maybe store it?)
 	size := 5
@@ -101,7 +116,7 @@ func (g *Gadget) getBounds() (utils.Point, utils.Point, duerror.DUError) {
 }
 
 func NewGadget(gadgetType GadgetType, point utils.Point) (*Gadget, duerror.DUError) {
-	if gadgetType&supportedType == 0 {
+	if gadgetType&supportedGadgetType == 0 {
 		return nil, duerror.NewInvalidArgumentError("gadget type is not supported")
 	}
 	if gadgetType == 0 {
@@ -111,6 +126,6 @@ func NewGadget(gadgetType GadgetType, point utils.Point) (*Gadget, duerror.DUErr
 		gadgetType: gadgetType,
 		point:      point,
 		layer:      0,
-		color:      utils.ToColor(drawdata.DefaultGadgetColor),
+		color:      utils.FromHex(drawdata.DefaultGadgetColor),
 	}, nil
 }

--- a/app/backend/component/gadget.go
+++ b/app/backend/component/gadget.go
@@ -76,7 +76,7 @@ func (g *Gadget) updateDrawData() duerror.DUError {
 	g.drawData.Layer = g.layer
 	g.drawData.Height = height
 	g.drawData.Width = width
-	g.drawData.Color = drawdata.DefaultGadgetColor
+	g.drawData.Color = utils.ToHex(g.color)
 	g.drawData.Attributes = atts
 
 	if g.updateParentDraw == nil {

--- a/app/backend/component/gadget.go
+++ b/app/backend/component/gadget.go
@@ -10,20 +10,19 @@ import (
 type GadgetType int
 
 const (
-	Class GadgetType = 1 << iota // 0x01
-	supportedType = Class
+	Class         GadgetType = 1 << iota // 0x01
+	supportedType            = Class
 )
 
 type Gadget struct {
-	gadgetType GadgetType
-	point utils.Point
-	layer int
-	attributes [][]attribute.Attribute // Gadget have multiple sections, each section have multiple attributes
-	color int
-	drawData drawdata.Gadget
+	gadgetType       GadgetType
+	point            utils.Point
+	layer            int
+	attributes       [][]attribute.Attribute // Gadget have multiple sections, each section have multiple attributes
+	color            int
+	drawData         drawdata.Gadget
 	updateParentDraw func() duerror.DUError
 }
-
 
 /*
 component interface
@@ -46,7 +45,7 @@ func (g *Gadget) SetLayer(layer int) duerror.DUError {
 	return nil
 }
 
-func (g *Gadget) GetDrawData() (any, duerror.DUError) {
+func (g *Gadget) GetDrawData() (drawdata.Component, duerror.DUError) {
 	return g.drawData, nil
 }
 
@@ -70,7 +69,7 @@ func (g *Gadget) updateDrawData() duerror.DUError {
 		height += drawdata.LineWidth
 	}
 	width := maxAttWidth + drawdata.Margin*2 + drawdata.LineWidth*2
-	
+
 	g.drawData.GadgetType = int(g.gadgetType)
 	g.drawData.X = g.point.X
 	g.drawData.Y = g.point.Y
@@ -79,7 +78,7 @@ func (g *Gadget) updateDrawData() duerror.DUError {
 	g.drawData.Width = width
 	g.drawData.Color = g.color
 	g.drawData.Attributes = atts
-	
+
 	if g.updateParentDraw == nil {
 		return nil
 	}
@@ -91,7 +90,6 @@ func (g *Gadget) RegisterUpdateParentDraw(update func() duerror.DUError) duerror
 	return nil
 }
 
-
 /*
 gadget func
 */
@@ -100,4 +98,19 @@ func (g *Gadget) getBounds() (utils.Point, utils.Point, duerror.DUError) {
 	//TODO: calculate the Bottom-Right point (maybe store it?)
 	size := 5
 	return g.point, utils.AddPoints(g.point, utils.Point{X: size, Y: size}), nil
+}
+
+func NewGadget(gadgetType GadgetType, point utils.Point) (*Gadget, duerror.DUError) {
+	if gadgetType&supportedType == 0 {
+		return nil, duerror.NewInvalidArgumentError("gadget type is not supported")
+	}
+	if gadgetType == 0 {
+		return nil, duerror.NewInvalidArgumentError("gadget type is 0")
+	}
+	return &Gadget{
+		gadgetType: gadgetType,
+		point:      point,
+		layer:      0,
+		color:      0,
+	}, nil
 }

--- a/app/backend/component/gadget.go
+++ b/app/backend/component/gadget.go
@@ -14,9 +14,6 @@ const (
 	supportedType            = Class
 )
 
-// a default gadget color (grey)
-const defaultGadgetColor = 0x808080
-
 type Gadget struct {
 	gadgetType       GadgetType
 	point            utils.Point
@@ -79,7 +76,7 @@ func (g *Gadget) updateDrawData() duerror.DUError {
 	g.drawData.Layer = g.layer
 	g.drawData.Height = height
 	g.drawData.Width = width
-	g.drawData.Color = defaultGadgetColor
+	g.drawData.Color = drawdata.DefaultGadgetColor
 	g.drawData.Attributes = atts
 
 	if g.updateParentDraw == nil {
@@ -114,6 +111,6 @@ func NewGadget(gadgetType GadgetType, point utils.Point) (*Gadget, duerror.DUErr
 		gadgetType: gadgetType,
 		point:      point,
 		layer:      0,
-		color:      utils.Color{R: 0, G: 0, B: 0}, // Default black color
+		color:      utils.ToColor(drawdata.DefaultGadgetColor),
 	}, nil
 }

--- a/app/backend/component/gadget.go
+++ b/app/backend/component/gadget.go
@@ -14,12 +14,15 @@ const (
 	supportedType            = Class
 )
 
+// a default gadget color (grey)
+const defaultGadgetColor = "#0x808080"
+
 type Gadget struct {
 	gadgetType       GadgetType
 	point            utils.Point
 	layer            int
 	attributes       [][]attribute.Attribute // Gadget have multiple sections, each section have multiple attributes
-	color            int
+	color            utils.Color
 	drawData         drawdata.Gadget
 	updateParentDraw func() duerror.DUError
 }
@@ -76,7 +79,7 @@ func (g *Gadget) updateDrawData() duerror.DUError {
 	g.drawData.Layer = g.layer
 	g.drawData.Height = height
 	g.drawData.Width = width
-	g.drawData.Color = g.color
+	g.drawData.Color = defaultGadgetColor
 	g.drawData.Attributes = atts
 
 	if g.updateParentDraw == nil {
@@ -111,6 +114,6 @@ func NewGadget(gadgetType GadgetType, point utils.Point) (*Gadget, duerror.DUErr
 		gadgetType: gadgetType,
 		point:      point,
 		layer:      0,
-		color:      0,
+		color:      utils.Color{R: 0, G: 0, B: 0}, // Default black color
 	}, nil
 }

--- a/app/backend/components/components.go
+++ b/app/backend/components/components.go
@@ -8,15 +8,15 @@ import (
 )
 
 type Components struct {
-	compoentsContainer componentsContainer
-	selectedComponents map[component.Component]bool
-	drawData           drawdata.Components
+	componentsContainer componentsContainer
+	selectedComponents  map[component.Component]bool
+	drawData            drawdata.Components
 }
 
 func NewComponents() *Components {
 	return &Components{
-		compoentsContainer: NewContainerMap(),
-		selectedComponents: make(map[component.Component]bool),
+		componentsContainer: NewContainerMap(),
+		selectedComponents:  make(map[component.Component]bool),
 		drawData: drawdata.Components{
 			Margin:    drawdata.Margin,
 			LineWidth: drawdata.LineWidth,
@@ -25,7 +25,7 @@ func NewComponents() *Components {
 }
 
 func (cs *Components) SelectComponent(point utils.Point) duerror.DUError {
-	comp, err := cs.compoentsContainer.Search(point)
+	comp, err := cs.componentsContainer.Search(point)
 	if err != nil {
 		return err
 	}
@@ -37,7 +37,7 @@ func (cs *Components) SelectComponent(point utils.Point) duerror.DUError {
 }
 
 func (cs *Components) UnselectComponent(point utils.Point) duerror.DUError {
-	comp, err := cs.compoentsContainer.Search(point)
+	comp, err := cs.componentsContainer.Search(point)
 	if err != nil {
 		return err
 	}
@@ -61,7 +61,7 @@ func (cs *Components) GetDrawData() (any, duerror.DUError) {
 
 func (cs *Components) updateDrawData() duerror.DUError {
 	arr := make([]drawdata.Component, 0, len(cs.selectedComponents))
-	for _, c := range cs.compoentsContainer.GetAll() {
+	for _, c := range cs.componentsContainer.GetAll() {
 		cDrawData, err := c.GetDrawData()
 		if err != nil {
 			return err
@@ -81,7 +81,7 @@ func (cs *Components) AddGadget(gadgetType component.GadgetType, point utils.Poi
 	if err != nil {
 		return err
 	}
-	err = cs.compoentsContainer.Insert(gadget)
+	err = cs.componentsContainer.Insert(gadget)
 	if err != nil {
 		return err
 	}

--- a/app/backend/components/components.go
+++ b/app/backend/components/components.go
@@ -10,7 +10,7 @@ import (
 type Components struct {
 	compoentsContainer componentsContainer
 	selectedComponents map[component.Component]bool
-	drawData drawdata.Components
+	drawData           drawdata.Components
 }
 
 func NewComponents() *Components {
@@ -18,7 +18,7 @@ func NewComponents() *Components {
 		compoentsContainer: NewContainerMap(),
 		selectedComponents: make(map[component.Component]bool),
 		drawData: drawdata.Components{
-			Margin: drawdata.Margin,
+			Margin:    drawdata.Margin,
 			LineWidth: drawdata.LineWidth,
 		},
 	}
@@ -74,4 +74,20 @@ func (cs *Components) updateDrawData() duerror.DUError {
 	cs.drawData.Components = arr
 	// TODO: should notify parent
 	return nil
+}
+
+func (cs *Components) AddGadget(gadgetType component.GadgetType, point utils.Point) (component.Component, duerror.DUError) {
+	gadget, err := component.NewGadget(gadgetType, point)
+	if err != nil {
+		return nil, err
+	}
+	err = cs.compoentsContainer.Insert(gadget)
+	if err != nil {
+		return nil, err
+	}
+	err = cs.updateDrawData()
+	if err != nil {
+		return nil, err
+	}
+	return gadget, nil
 }

--- a/app/backend/components/components.go
+++ b/app/backend/components/components.go
@@ -76,18 +76,18 @@ func (cs *Components) updateDrawData() duerror.DUError {
 	return nil
 }
 
-func (cs *Components) AddGadget(gadgetType component.GadgetType, point utils.Point) (component.Component, duerror.DUError) {
+func (cs *Components) AddGadget(gadgetType component.GadgetType, point utils.Point) duerror.DUError {
 	gadget, err := component.NewGadget(gadgetType, point)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	err = cs.compoentsContainer.Insert(gadget)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	err = cs.updateDrawData()
 	if err != nil {
-		return nil, err
+		return err
 	}
-	return gadget, nil
+	return nil
 }

--- a/app/backend/umldiagram/umldiagram.go
+++ b/app/backend/umldiagram/umldiagram.go
@@ -24,14 +24,12 @@ func isValidDiagramType(input DiagramType) bool {
 
 // Diagram represents a UML diagram
 type UMLDiagram struct {
-	id           uuid.UUID
-	name         string
-	diagramType  DiagramType // e.g., "Class", "UseCase", "Sequence"
-	lastModified time.Time
-	startPoint   utils.Point // for dragging and linking ass
-	/* TODO */
-	// add background color
-
+	id              uuid.UUID
+	name            string
+	diagramType     DiagramType // e.g., "Class", "UseCase", "Sequence"
+	lastModified    time.Time
+	startPoint      utils.Point // for dragging and linking ass
+	backgroundColor utils.Color
 }
 
 // NewUMLDiagram creates a new UMLDiagram instance
@@ -47,11 +45,12 @@ func NewUMLDiagram(name string, dt DiagramType) (*UMLDiagram, duerror.DUError) {
 	}
 
 	return &UMLDiagram{
-		id:           id,
-		name:         name,
-		diagramType:  dt,
-		lastModified: time.Now(),
-		startPoint:   utils.Point{X: 0, Y: 0},
+		id:              id,
+		name:            name,
+		diagramType:     dt,
+		lastModified:    time.Now(),
+		startPoint:      utils.Point{X: 0, Y: 0},
+		backgroundColor: utils.Color{R: 255, G: 255, B: 255}, // Default white background
 	}, nil
 }
 

--- a/app/backend/umldiagram/umldiagram.go
+++ b/app/backend/umldiagram/umldiagram.go
@@ -6,7 +6,6 @@ import (
 	"Dr.uml/backend/component"
 	"Dr.uml/backend/utils"
 	"Dr.uml/backend/utils/duerror"
-	"github.com/google/uuid"
 )
 
 type DiagramType int
@@ -24,7 +23,6 @@ func isValidDiagramType(input DiagramType) bool {
 
 // Diagram represents a UML diagram
 type UMLDiagram struct {
-	id              uuid.UUID
 	name            string
 	diagramType     DiagramType // e.g., "Class", "UseCase", "Sequence"
 	lastModified    time.Time
@@ -34,7 +32,6 @@ type UMLDiagram struct {
 
 // NewUMLDiagram creates a new UMLDiagram instance
 func NewUMLDiagram(name string, dt DiagramType) (*UMLDiagram, duerror.DUError) {
-	id := uuid.New()
 
 	if !utils.IsValidFilePath(name) {
 		return nil, duerror.NewInvalidArgumentError("Invalid diagram name")
@@ -45,7 +42,6 @@ func NewUMLDiagram(name string, dt DiagramType) (*UMLDiagram, duerror.DUError) {
 	}
 
 	return &UMLDiagram{
-		id:              id,
 		name:            name,
 		diagramType:     dt,
 		lastModified:    time.Now(),
@@ -54,12 +50,12 @@ func NewUMLDiagram(name string, dt DiagramType) (*UMLDiagram, duerror.DUError) {
 	}, nil
 }
 
-func (ud *UMLDiagram) GetId() uuid.UUID {
-	return ud.id
-}
-
 func (ud *UMLDiagram) GetName() string {
 	return ud.name
+}
+
+func (ud *UMLDiagram) GetDiagramType() DiagramType {
+	return ud.diagramType
 }
 
 func NewUMLDiagramWithPath(path string) (*UMLDiagram, error) {
@@ -67,7 +63,6 @@ func NewUMLDiagramWithPath(path string) (*UMLDiagram, error) {
 		return nil, duerror.NewInvalidArgumentError("Invalid diagram name")
 	}
 	return &UMLDiagram{
-		id:           uuid.New(),
 		name:         path,
 		diagramType:  ClassDiagram,
 		lastModified: time.Now(),
@@ -76,7 +71,6 @@ func NewUMLDiagramWithPath(path string) (*UMLDiagram, error) {
 }
 
 func (ud *UMLDiagram) AddGadget(gadgetType component.GadgetType) error {
-	// Add a gadget to the diagram
-	/* TODO */
+
 	return nil
 }

--- a/app/backend/umldiagram/umldiagram.go
+++ b/app/backend/umldiagram/umldiagram.go
@@ -4,6 +4,8 @@ import (
 	"time"
 
 	"Dr.uml/backend/component"
+	"Dr.uml/backend/component/drawdata"
+	"Dr.uml/backend/components"
 	"Dr.uml/backend/utils"
 	"Dr.uml/backend/utils/duerror"
 )
@@ -28,6 +30,7 @@ type UMLDiagram struct {
 	lastModified    time.Time
 	startPoint      utils.Point // for dragging and linking ass
 	backgroundColor utils.Color
+	components      *components.Components
 }
 
 // NewUMLDiagram creates a new UMLDiagram instance
@@ -47,6 +50,7 @@ func NewUMLDiagram(name string, dt DiagramType) (*UMLDiagram, duerror.DUError) {
 		lastModified:    time.Now(),
 		startPoint:      utils.Point{X: 0, Y: 0},
 		backgroundColor: utils.Color{R: 255, G: 255, B: 255}, // Default white background
+		components:      components.NewComponents(),
 	}, nil
 }
 
@@ -70,7 +74,23 @@ func NewUMLDiagramWithPath(path string) (*UMLDiagram, error) {
 	}, nil
 }
 
-func (ud *UMLDiagram) AddGadget(gadgetType component.GadgetType) error {
+func (ud *UMLDiagram) AddGadget(gadgetType component.GadgetType, point utils.Point) (drawdata.Gadget, duerror.DUError) {
 
-	return nil
+	comp, err := ud.components.AddGadget(gadgetType, point)
+	if err != nil {
+		return drawdata.Gadget{}, err
+	}
+
+	dd, err := comp.GetDrawData()
+	if err != nil {
+		return drawdata.Gadget{}, err
+	}
+
+	gadgetdd, ok := dd.(drawdata.Gadget)
+	if !ok {
+		return drawdata.Gadget{}, duerror.NewInvalidArgumentError("Invalid gadget type")
+	}
+
+	return gadgetdd, nil
+
 }

--- a/app/backend/umldiagram/umldiagram.go
+++ b/app/backend/umldiagram/umldiagram.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"Dr.uml/backend/component"
-	"Dr.uml/backend/component/drawdata"
 	"Dr.uml/backend/components"
 	"Dr.uml/backend/utils"
 	"Dr.uml/backend/utils/duerror"
@@ -74,23 +73,12 @@ func NewUMLDiagramWithPath(path string) (*UMLDiagram, error) {
 	}, nil
 }
 
-func (ud *UMLDiagram) AddGadget(gadgetType component.GadgetType, point utils.Point) (drawdata.Gadget, duerror.DUError) {
+func (ud *UMLDiagram) AddGadget(gadgetType component.GadgetType, point utils.Point) duerror.DUError {
 
-	comp, err := ud.components.AddGadget(gadgetType, point)
+	err := ud.components.AddGadget(gadgetType, point)
 	if err != nil {
-		return drawdata.Gadget{}, err
+		return err
 	}
-
-	dd, err := comp.GetDrawData()
-	if err != nil {
-		return drawdata.Gadget{}, err
-	}
-
-	gadgetdd, ok := dd.(drawdata.Gadget)
-	if !ok {
-		return drawdata.Gadget{}, duerror.NewInvalidArgumentError("Invalid gadget type")
-	}
-
-	return gadgetdd, nil
+	return nil
 
 }

--- a/app/backend/umldiagram/umldiagram_test.go
+++ b/app/backend/umldiagram/umldiagram_test.go
@@ -73,6 +73,9 @@ func TestNewUMLDiagram(t *testing.T) {
 				assert.Equal(t, tt.diagramType, diagram.diagramType)
 				assert.WithinDuration(t, time.Now(), diagram.lastModified, time.Second)
 				assert.Equal(t, utils.Point{X: 0, Y: 0}, diagram.startPoint)
+				// New assertions
+				assert.Equal(t, utils.Color{R: 255, G: 255, B: 255}, diagram.backgroundColor)
+				assert.NotNil(t, diagram.components)
 			}
 		})
 	}
@@ -126,8 +129,9 @@ func TestUMLDiagramGetters(t *testing.T) {
 
 	assert.Equal(t, "TestDiagram", diagram.GetName())
 
-	err = diagram.AddGadget(component.Class)
+	comp, err := diagram.AddGadget(component.Class, utils.Point{X: 10, Y: 20})
 	assert.NoError(t, err)
+	assert.NotNil(t, comp)
 }
 
 func TestNewUMLDiagramWithPath(t *testing.T) {

--- a/app/backend/umldiagram/umldiagram_test.go
+++ b/app/backend/umldiagram/umldiagram_test.go
@@ -6,7 +6,6 @@ import (
 
 	"Dr.uml/backend/component"
 	"Dr.uml/backend/utils"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -70,7 +69,6 @@ func TestNewUMLDiagram(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.NotNil(t, diagram)
-				assert.NotEqual(t, uuid.Nil, diagram.GetId())
 				assert.Equal(t, tt.inputName, diagram.GetName())
 				assert.Equal(t, tt.diagramType, diagram.diagramType)
 				assert.WithinDuration(t, time.Now(), diagram.lastModified, time.Second)
@@ -126,7 +124,6 @@ func TestUMLDiagramGetters(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, diagram)
 
-	assert.NotEqual(t, uuid.Nil, diagram.GetId())
 	assert.Equal(t, "TestDiagram", diagram.GetName())
 
 	err = diagram.AddGadget(component.Class)

--- a/app/backend/umldiagram/umldiagram_test.go
+++ b/app/backend/umldiagram/umldiagram_test.go
@@ -129,9 +129,8 @@ func TestUMLDiagramGetters(t *testing.T) {
 
 	assert.Equal(t, "TestDiagram", diagram.GetName())
 
-	comp, err := diagram.AddGadget(component.Class, utils.Point{X: 10, Y: 20})
+	err = diagram.AddGadget(component.Class, utils.Point{X: 10, Y: 20})
 	assert.NoError(t, err)
-	assert.NotNil(t, comp)
 }
 
 func TestNewUMLDiagramWithPath(t *testing.T) {

--- a/app/backend/umlproject/umlproject.go
+++ b/app/backend/umlproject/umlproject.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"Dr.uml/backend/component"
-	"Dr.uml/backend/component/drawdata"
 	"Dr.uml/backend/umldiagram"
 	"Dr.uml/backend/utils"
 	"Dr.uml/backend/utils/duerror"
@@ -45,6 +44,7 @@ func (p *UMLProject) OpenProject() ([]*umldiagram.UMLDiagram, []string, duerror.
 			return nil, nil, duerror.NewInvalidArgumentError("Failed to create diagram")
 		}
 		p.activeDiagrams[d.GetName()] = d
+		activeDiagrams = append(activeDiagrams, d)
 	}
 
 	return activeDiagrams, p.GetAvailableDiagrams(), nil
@@ -81,17 +81,14 @@ func (p *UMLProject) SelectDiagram(diagramName string) duerror.DUError {
 func (p *UMLProject) AddGadget(
 	gadgetType component.GadgetType,
 	point utils.Point,
-) (drawdata.Gadget, duerror.DUError) {
+) duerror.DUError {
 
-	dd, err := p.currentDiagram.AddGadget(gadgetType, point)
+	err := p.currentDiagram.AddGadget(gadgetType, point)
 	if err != nil {
-		return drawdata.Gadget{}, err
+		return err
 	}
 	p.lastModified = time.Now()
-	if dd.GadgetType != 1 {
-		p.activeDiagrams[p.currentDiagram.GetName()] = p.currentDiagram
-	}
-	return dd, nil
+	return nil
 
 }
 

--- a/app/backend/umlproject/umlproject.go
+++ b/app/backend/umlproject/umlproject.go
@@ -87,10 +87,8 @@ func (p *UMLProject) AddNewDiagram(
 	diagramType umldiagram.DiagramType,
 	name string,
 ) duerror.DUError {
-	for _, diagram := range p.diagrams {
-		if diagram.GetName() == name {
-			return duerror.NewInvalidArgumentError("Diagram name already exists")
-		}
+	if _, exists := p.diagrams[name]; exists {
+		return duerror.NewInvalidArgumentError("Diagram name already exists")
 	}
 
 	diagram, err := umldiagram.NewUMLDiagram(name, diagramType)

--- a/app/backend/umlproject/umlproject.go
+++ b/app/backend/umlproject/umlproject.go
@@ -35,19 +35,9 @@ func (p *UMLProject) GetName() string {
 	return p.name
 }
 
-// GetLastModified returns the last modified time of the UMLProject
-func (p *UMLProject) OpenProject() ([]*umldiagram.UMLDiagram, []string, duerror.DUError) {
-	activeDiagrams := make([]*umldiagram.UMLDiagram, 0, len(p.activeDiagrams))
-	for _, diagram := range p.openedDiagrams {
-		d, err := umldiagram.NewUMLDiagram(diagram.GetName(), diagram.GetDiagramType())
-		if err != nil {
-			return nil, nil, duerror.NewInvalidArgumentError("Failed to create diagram")
-		}
-		p.activeDiagrams[d.GetName()] = d
-		activeDiagrams = append(activeDiagrams, d)
-	}
-
-	return activeDiagrams, p.GetAvailableDiagrams(), nil
+// OpenProject returns the active diagrams and available diagrams in the project
+func (p *UMLProject) OpenProject() ([]string, []string, duerror.DUError) {
+	return p.GetLastOpenedDiagrams(), p.GetAvailableDiagrams(), nil
 }
 
 // GetAvailableDiagrams returns a list of the names of all available diagrams in the project

--- a/app/backend/umlproject/umlproject.go
+++ b/app/backend/umlproject/umlproject.go
@@ -3,8 +3,6 @@ package umlproject
 import (
 	"time"
 
-	"github.com/google/uuid"
-
 	"Dr.uml/backend/component"
 	"Dr.uml/backend/umldiagram"
 	"Dr.uml/backend/utils/duerror"
@@ -13,9 +11,10 @@ import (
 type UMLProject struct {
 	name           string
 	lastModified   time.Time
-	currentDiagram *umldiagram.UMLDiagram               // The currently selected diagram
-	diagrams       map[uuid.UUID]*umldiagram.UMLDiagram // Use a map to store diagrams, keyed by their ID
-	openedDiagrams map[uuid.UUID]*umldiagram.UMLDiagram // Keep track of opened diagrams
+	currentDiagram *umldiagram.UMLDiagram            // The currently selected diagram
+	diagrams       map[string]*umldiagram.UMLDiagram // Use a map to store diagrams, keyed by their ID
+	openedDiagrams map[string]*umldiagram.UMLDiagram // Keep track of opened diagrams
+	activeDiagrams map[string]*umldiagram.UMLDiagram // Keep track of active diagrams
 }
 
 // NewUMLProject creates a new UMLProject instance
@@ -24,8 +23,9 @@ func NewUMLProject(name string) *UMLProject {
 	return &UMLProject{
 		name:           name,
 		lastModified:   time.Now(),
-		diagrams:       make(map[uuid.UUID]*umldiagram.UMLDiagram),
-		openedDiagrams: make(map[uuid.UUID]*umldiagram.UMLDiagram),
+		diagrams:       make(map[string]*umldiagram.UMLDiagram),
+		openedDiagrams: make(map[string]*umldiagram.UMLDiagram),
+		activeDiagrams: make(map[string]*umldiagram.UMLDiagram),
 	}
 }
 
@@ -35,20 +35,17 @@ func (p *UMLProject) GetName() string {
 }
 
 // GetLastModified returns the last modified time of the UMLProject
-func (p *UMLProject) OpenProject() ([]*umldiagram.UMLDiagram, []string, []uuid.UUID) {
-	openedDiagrams := make([]*umldiagram.UMLDiagram, 0, len(p.openedDiagrams))
-	uuidList := make([]uuid.UUID, 0, len(p.openedDiagrams))
+func (p *UMLProject) OpenProject() ([]*umldiagram.UMLDiagram, []string, duerror.DUError) {
+	activeDiagrams := make([]*umldiagram.UMLDiagram, 0, len(p.activeDiagrams))
 	for _, diagram := range p.openedDiagrams {
-		openedDiagrams = append(openedDiagrams, diagram)
-		uuidList = append(uuidList, diagram.GetId())
+		d, err := umldiagram.NewUMLDiagram(diagram.GetName(), diagram.GetDiagramType())
+		if err != nil {
+			return nil, nil, duerror.NewInvalidArgumentError("Failed to create diagram")
+		}
+		p.activeDiagrams[d.GetName()] = d
 	}
 
-	diagramList := make([]string, 0, len(p.diagrams))
-	for _, diagram := range p.diagrams {
-		diagramList = append(diagramList, diagram.GetName())
-	}
-
-	return openedDiagrams, diagramList, uuidList
+	return activeDiagrams, p.GetAvailableDiagrams(), nil
 }
 
 // GetAvailableDiagrams returns a list of the names of all available diagrams in the project
@@ -70,8 +67,8 @@ func (p *UMLProject) GetLastOpenedDiagrams() []string {
 }
 
 // SelectDiagram sets the current diagram to the one with the given ID
-func (p *UMLProject) SelectDiagram(diagramID uuid.UUID) duerror.DUError {
-	if diagram, ok := p.diagrams[diagramID]; ok {
+func (p *UMLProject) SelectDiagram(diagramName string) duerror.DUError {
+	if diagram, ok := p.diagrams[diagramName]; ok {
 		p.currentDiagram = diagram
 		return nil
 	}
@@ -81,9 +78,9 @@ func (p *UMLProject) SelectDiagram(diagramID uuid.UUID) duerror.DUError {
 // AddGadget
 func (p *UMLProject) AddGadget(
 	gadgetType component.GadgetType,
-	diagramID uuid.UUID,
+	diagramName string,
 ) duerror.DUError {
-	if diagram, ok := p.diagrams[diagramID]; ok {
+	if diagram, ok := p.diagrams[diagramName]; ok {
 		// Add the gadget to the diagram
 		diagram.AddGadget(gadgetType)
 		p.lastModified = time.Now()
@@ -97,14 +94,13 @@ func (p *UMLProject) AddNewDiagram(
 	diagramType umldiagram.DiagramType,
 	name string,
 ) duerror.DUError {
-	id := uuid.New()
 	diagram, err := umldiagram.NewUMLDiagram(name, diagramType)
 	if err != nil {
 		return err
 	}
-	p.diagrams[id] = diagram
+	p.diagrams[name] = diagram
 	p.currentDiagram = diagram
-	p.openedDiagrams[id] = diagram
+	p.openedDiagrams[name] = diagram
 	p.lastModified = time.Now()
 	return nil
 
@@ -116,9 +112,9 @@ func (p *UMLProject) createDiagram(path string) duerror.DUError {
 	if err != nil {
 		return err
 	}
-	p.diagrams[diagram.GetId()] = diagram
+	p.diagrams[diagram.GetName()] = diagram
 	p.currentDiagram = diagram
-	p.openedDiagrams[diagram.GetId()] = diagram
+	p.openedDiagrams[diagram.GetName()] = diagram
 	p.lastModified = time.Now()
 	return nil
 }

--- a/app/backend/umlproject/umlproject_test.go
+++ b/app/backend/umlproject/umlproject_test.go
@@ -57,8 +57,13 @@ func TestOpenProject(t *testing.T) {
 		t.Errorf("Expected no error, got %v", duErr)
 	}
 
-	// activeDiagrams should be empty initially because we're not setting any active diagrams
-	// even though the slice is initialized with a capacity based on activeDiagrams
+	// activeDiagrams should be 1 since we opened one diagram
+	// and added it to openedDiagrams
+	// Check if activeDiagrams is not nil
+	if activeDiagrams == nil {
+		t.Error("Expected activeDiagrams to be not nil")
+	}
+	// Check if activeDiagrams has 1 diagram
 	if len(activeDiagrams) != 1 {
 		t.Errorf("Expected 0 active diagrams, got %d", len(activeDiagrams))
 	}

--- a/app/backend/umlproject/umlproject_test.go
+++ b/app/backend/umlproject/umlproject_test.go
@@ -88,14 +88,9 @@ func TestOpenProject(t *testing.T) {
 		}
 	}
 
-	// Verify activeDiagrams map was populated
-	if len(project.activeDiagrams) != 1 {
-		t.Errorf("Expected 1 active diagram in map, got %d", len(project.activeDiagrams))
-	}
-
-	// Check if the active diagram was created with the correct name
-	if _, exists := project.activeDiagrams["Diagram1"]; !exists {
-		t.Errorf("Expected 'Diagram1' to be in active diagrams map")
+	// Verify activeDiagrams map was not populated
+	if len(project.activeDiagrams) != 0 {
+		t.Errorf("Expected 0 active diagram in map, got %d", len(project.activeDiagrams))
 	}
 }
 

--- a/app/backend/umlproject/umlproject_test.go
+++ b/app/backend/umlproject/umlproject_test.go
@@ -65,7 +65,7 @@ func TestOpenProject(t *testing.T) {
 	}
 	// Check if activeDiagrams has 1 diagram
 	if len(activeDiagrams) != 1 {
-		t.Errorf("Expected 0 active diagrams, got %d", len(activeDiagrams))
+		t.Errorf("Expected 1 active diagrams, got %d", len(activeDiagrams))
 	}
 
 	// Check available diagrams (diagram names)

--- a/app/backend/umlproject/umlproject_test.go
+++ b/app/backend/umlproject/umlproject_test.go
@@ -59,7 +59,7 @@ func TestOpenProject(t *testing.T) {
 
 	// activeDiagrams should be empty initially because we're not setting any active diagrams
 	// even though the slice is initialized with a capacity based on activeDiagrams
-	if len(activeDiagrams) != 0 {
+	if len(activeDiagrams) != 1 {
 		t.Errorf("Expected 0 active diagrams, got %d", len(activeDiagrams))
 	}
 
@@ -203,14 +203,11 @@ func TestAddGadget(t *testing.T) {
 	project.SelectDiagram(diagram.GetName())
 
 	// TODO: assert GadgetType in drawdata
-	_, err = project.AddGadget(gadgetType, utils.Point{X: 10, Y: 20})
+	err = project.AddGadget(gadgetType, utils.Point{X: 10, Y: 20})
+
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
 	}
-	// if dd.GadgetType != int(gadgetType) {
-	// 	t.Errorf("Expected gadget type %d, got %d", gadgetType, dd.GadgetType)
-	// }
-
 	if !project.lastModified.After(previousModified) {
 		t.Error("Expected lastModified to be updated")
 	}

--- a/app/backend/utils/color.go
+++ b/app/backend/utils/color.go
@@ -4,11 +4,11 @@ type Color struct {
 	R, G, B uint8
 }
 
-func ToHex(c Color) int {
+func (c *Color) ToHex() int {
 	return int(c.R)<<16 | int(c.G)<<8 | int(c.B)
 }
 
-func ToColor(i int) Color {
+func FromHex(i int) Color {
 	return Color{
 		R: uint8((i >> 16) & 0xFF),
 		G: uint8((i >> 8) & 0xFF),

--- a/app/backend/utils/color.go
+++ b/app/backend/utils/color.go
@@ -1,13 +1,9 @@
 package utils
 
-import (
-	"fmt"
-)
-
 type Color struct {
 	R, G, B uint8
 }
 
-func (c Color) ToHex() string {
-	return "#" + fmt.Sprintf("%02X%02X%02X", c.R, c.G, c.B)
+func (c Color) ToHex() int {
+	return int(c.R)<<16 | int(c.G)<<8 | int(c.B)
 }

--- a/app/backend/utils/color.go
+++ b/app/backend/utils/color.go
@@ -4,7 +4,7 @@ type Color struct {
 	R, G, B uint8
 }
 
-func (c Color) ToHex() int {
+func ToHex(c Color) int {
 	return int(c.R)<<16 | int(c.G)<<8 | int(c.B)
 }
 

--- a/app/backend/utils/color.go
+++ b/app/backend/utils/color.go
@@ -1,5 +1,13 @@
 package utils
 
+import (
+	"fmt"
+)
+
 type Color struct {
 	R, G, B uint8
+}
+
+func (c Color) ToHex() string {
+	return "#" + fmt.Sprintf("%02X%02X%02X", c.R, c.G, c.B)
 }

--- a/app/backend/utils/color.go
+++ b/app/backend/utils/color.go
@@ -7,3 +7,12 @@ type Color struct {
 func (c Color) ToHex() int {
 	return int(c.R)<<16 | int(c.G)<<8 | int(c.B)
 }
+
+func ToColor(i int) Color {
+	return Color{
+		R: uint8((i >> 16) & 0xFF),
+		G: uint8((i >> 8) & 0xFF),
+		B: uint8(i & 0xFF),
+	}
+	// return Color{R: uint8(i >> 16), G: uint8(i >> 8), B: uint8(i)}
+}

--- a/app/go.mod
+++ b/app/go.mod
@@ -5,7 +5,6 @@ go 1.23.0
 toolchain go1.23.8
 
 require (
-	github.com/google/uuid v1.6.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.10.0
 	github.com/wailsapp/wails/v2 v2.10.1
@@ -17,6 +16,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/jchv/go-winloader v0.0.0-20210711035445-715c2860da7e // indirect
 	github.com/labstack/echo/v4 v4.13.3 // indirect
 	github.com/labstack/gommon v0.4.2 // indirect


### PR DESCRIPTION
### Major
- replace diagram id with diagram name as key in UMLprojects' maps
- connection between diagram and components

### Small
ignore some dir

### Reminder
old
```
func (g *Gadget) GetDrawData() (any, duerror.DUError) {
	return g.drawData, nil
}
```
new
```
func (g *Gadget) GetDrawData() (drawdata.Component, duerror.DUError) {
	return g.drawData, nil
}
```
<details>
<summary>"any" doesn't work</summary>

```
 backend\components\components.go:84:69: cannot use gadget (variable of type *component.Gadget) as component.Component value in argument to cs.compoentsContainer.Insert: *component.Gadget does not implement component.Component (wrong type for method GetDrawData)
                have GetDrawData() (any, duerror.DUError)
                want GetDrawData() (drawdata.Component, duerror.DUError)
```
</details>
