### PR TITLE
Implement command pattern for component operations and add unit tests

### DIFF
--- a/app/backend/command/manager.go
+++ b/app/backend/command/manager.go
@@ -1,4 +1,65 @@
 package command
 
+import "Dr.uml/backend/utils/duerror"
+
+// Command defines the basic behaviour for all commands.
+type Command interface {
+	Execute() duerror.DUError
+	Unexecute() duerror.DUError
+}
+
+// Manager keeps track of executed commands and provides undo/redo
+// capabilities.
 type Manager struct {
+	undoStack []Command
+	redoStack []Command
+}
+
+// NewManager creates a new command manager instance.
+func NewManager() *Manager {
+	return &Manager{
+		undoStack: make([]Command, 0),
+		redoStack: make([]Command, 0),
+	}
+}
+
+// ExecuteCommand runs the given command and stores it for undo.
+func (m *Manager) ExecuteCommand(cmd Command) duerror.DUError {
+	if cmd == nil {
+		return duerror.NewInvalidArgumentError("command is nil")
+	}
+	if err := cmd.Execute(); err != nil {
+		return err
+	}
+	m.undoStack = append(m.undoStack, cmd)
+	m.redoStack = nil
+	return nil
+}
+
+// Undo reverts the last executed command.
+func (m *Manager) Undo() duerror.DUError {
+	if len(m.undoStack) == 0 {
+		return nil
+	}
+	cmd := m.undoStack[len(m.undoStack)-1]
+	m.undoStack = m.undoStack[:len(m.undoStack)-1]
+	if err := cmd.Unexecute(); err != nil {
+		return err
+	}
+	m.redoStack = append(m.redoStack, cmd)
+	return nil
+}
+
+// Redo re-executes the last undone command.
+func (m *Manager) Redo() duerror.DUError {
+	if len(m.redoStack) == 0 {
+		return nil
+	}
+	cmd := m.redoStack[len(m.redoStack)-1]
+	m.redoStack = m.redoStack[:len(m.redoStack)-1]
+	if err := cmd.Execute(); err != nil {
+		return err
+	}
+	m.undoStack = append(m.undoStack, cmd)
+	return nil
 }

--- a/app/backend/command/manager_test.go
+++ b/app/backend/command/manager_test.go
@@ -1,0 +1,94 @@
+package command
+
+import (
+	"testing"
+
+	"Dr.uml/backend/utils/duerror"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockCommand struct {
+	execCount int
+	undoCount int
+	execErr   duerror.DUError
+	undoErr   duerror.DUError
+}
+
+func (m *mockCommand) Execute() duerror.DUError {
+	m.execCount++
+	return m.execErr
+}
+
+func (m *mockCommand) Unexecute() duerror.DUError {
+	m.undoCount++
+	return m.undoErr
+}
+
+func TestManager_ExecuteCommand(t *testing.T) {
+	mgr := NewManager()
+	cmd := &mockCommand{}
+
+	err := mgr.ExecuteCommand(cmd)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, cmd.execCount)
+	assert.Len(t, mgr.undoStack, 1)
+	assert.Len(t, mgr.redoStack, 0)
+}
+
+func TestManager_ExecuteCommand_Error(t *testing.T) {
+	mgr := NewManager()
+	cmd := &mockCommand{execErr: duerror.NewInvalidArgumentError("boom")}
+
+	err := mgr.ExecuteCommand(cmd)
+	assert.Error(t, err)
+	assert.Len(t, mgr.undoStack, 0)
+}
+
+func TestManager_UndoRedo(t *testing.T) {
+	mgr := NewManager()
+	cmd := &mockCommand{}
+	_ = mgr.ExecuteCommand(cmd)
+
+	err := mgr.Undo()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, cmd.undoCount)
+	assert.Len(t, mgr.undoStack, 0)
+	assert.Len(t, mgr.redoStack, 1)
+
+	err = mgr.Redo()
+	assert.NoError(t, err)
+	assert.Equal(t, 2, cmd.execCount) // executed again
+	assert.Len(t, mgr.undoStack, 1)
+	assert.Len(t, mgr.redoStack, 0)
+}
+
+func TestManager_UndoEmptyRedoEmpty(t *testing.T) {
+	mgr := NewManager()
+	// Undo with empty stack
+	err := mgr.Undo()
+	assert.NoError(t, err)
+	err = mgr.Redo()
+	assert.NoError(t, err)
+}
+
+func TestManager_UndoError(t *testing.T) {
+	mgr := NewManager()
+	cmd := &mockCommand{undoErr: duerror.NewInvalidArgumentError("fail")}
+	_ = mgr.ExecuteCommand(cmd)
+
+	err := mgr.Undo()
+	assert.Error(t, err)
+	assert.Len(t, mgr.redoStack, 0)
+}
+
+func TestManager_RedoError(t *testing.T) {
+	mgr := NewManager()
+	cmd := &mockCommand{undoErr: nil}
+	_ = mgr.ExecuteCommand(cmd)
+	_ = mgr.Undo()
+
+	cmd.execErr = duerror.NewInvalidArgumentError("redo fail")
+	err := mgr.Redo()
+	assert.Error(t, err)
+	assert.Len(t, mgr.undoStack, 0)
+}

--- a/app/backend/component/gadget.go
+++ b/app/backend/component/gadget.go
@@ -101,6 +101,13 @@ func (g *Gadget) GetIsSelected() bool {
 	return g.IsSelected
 }
 
+func (g *Gadget) GetAttributes(section int) []*attribute.Attribute {
+	if err := g.validateSection(section); err != nil {
+		return nil
+	}
+	return g.attributes[section]
+}
+
 // Setter
 func (g *Gadget) SetPoint(point utils.Point) duerror.DUError {
 	g.point = point

--- a/app/backend/component/gadget_test.go
+++ b/app/backend/component/gadget_test.go
@@ -101,6 +101,28 @@ func TestGetAttributesLen(t *testing.T) {
 	assert.Equal(t, []int{1, 3, 4}, g.GetAttributesLen())
 }
 
+func TestGetAttributes(t *testing.T) {
+	g := newEmptyGadget(Class, utils.Point{X: 1, Y: 1})
+
+	// Test valid section
+	attrs := g.GetAttributes(1)  // Section 1 has attributes by default
+	assert.NotNil(t, attrs)
+	assert.Equal(t, 3, len(attrs)) // Should have 3 attributes by default in section 1
+
+	// Add a new attribute and verify
+	assert.NoError(t, g.AddAttribute(1, "test attr"))
+	attrs = g.GetAttributes(1)
+	assert.NotNil(t, attrs)
+	assert.Equal(t, 4, len(attrs))
+	assert.Equal(t, "test attr", attrs[3].GetContent())  // New attribute should be at the end
+
+	// Test invalid section
+	attrs = g.GetAttributes(-1)
+	assert.Nil(t, attrs)
+	attrs = g.GetAttributes(len(g.attributes))
+	assert.Nil(t, attrs)
+}
+
 // Setter
 func TestSetPoint(t *testing.T) {
 	g := newEmptyGadget(Class, utils.Point{X: 1, Y: 1})

--- a/app/backend/component/gadget_test.go
+++ b/app/backend/component/gadget_test.go
@@ -105,7 +105,7 @@ func TestGetAttributes(t *testing.T) {
 	g := newEmptyGadget(Class, utils.Point{X: 1, Y: 1})
 
 	// Test valid section
-	attrs := g.GetAttributes(1)  // Section 1 has attributes by default
+	attrs := g.GetAttributes(1) // Section 1 has attributes by default
 	assert.NotNil(t, attrs)
 	assert.Equal(t, 3, len(attrs)) // Should have 3 attributes by default in section 1
 
@@ -114,7 +114,7 @@ func TestGetAttributes(t *testing.T) {
 	attrs = g.GetAttributes(1)
 	assert.NotNil(t, attrs)
 	assert.Equal(t, 4, len(attrs))
-	assert.Equal(t, "test attr", attrs[3].GetContent())  // New attribute should be at the end
+	assert.Equal(t, "test attr", attrs[3].GetContent()) // New attribute should be at the end
 
 	// Test invalid section
 	attrs = g.GetAttributes(-1)

--- a/app/backend/umldiagram/commands.go
+++ b/app/backend/umldiagram/commands.go
@@ -1,0 +1,150 @@
+package umldiagram
+
+import (
+	"time"
+
+	"Dr.uml/backend/command"
+	"Dr.uml/backend/component"
+	"Dr.uml/backend/utils"
+	"Dr.uml/backend/utils/duerror"
+)
+
+// addGadgetCommand adds a gadget to the diagram.
+type addGadgetCommand struct {
+	diagram    *UMLDiagram
+	gadgetType component.GadgetType
+	point      utils.Point
+	layer      int
+	color      string
+	header     string
+	gadget     *component.Gadget
+}
+
+func (c *addGadgetCommand) Execute() duerror.DUError {
+	g, err := component.NewGadget(c.gadgetType, c.point, c.layer, c.color, c.header)
+	if err != nil {
+		return err
+	}
+	if err = g.RegisterUpdateParentDraw(c.diagram.updateDrawData); err != nil {
+		return err
+	}
+	if err = c.diagram.componentsContainer.Insert(g); err != nil {
+		return err
+	}
+	c.diagram.associations[g] = [2][]*component.Association{{}, {}}
+	c.diagram.lastModified = time.Now()
+	c.gadget = g
+	return c.diagram.updateDrawData()
+}
+
+func (c *addGadgetCommand) Unexecute() duerror.DUError {
+	if c.gadget == nil {
+		return nil
+	}
+	return c.diagram.removeGadget(c.gadget)
+}
+
+// addAssociationCommand creates an association between two gadgets.
+type addAssociationCommand struct {
+	diagram     *UMLDiagram
+	assType     component.AssociationType
+	start, end  utils.Point
+	association *component.Association
+}
+
+func (c *addAssociationCommand) Execute() duerror.DUError {
+	stGad, err := c.diagram.componentsContainer.SearchGadget(c.start)
+	if err != nil {
+		return err
+	}
+	if stGad == nil {
+		return duerror.NewInvalidArgumentError("start point does not contain a gadget")
+	}
+	enGad, err := c.diagram.componentsContainer.SearchGadget(c.end)
+	if err != nil {
+		return err
+	}
+	if enGad == nil {
+		return duerror.NewInvalidArgumentError("end point does not contain a gadget")
+	}
+	parents := [2]*component.Gadget{stGad, enGad}
+	a, err := component.NewAssociation(parents, component.AssociationType(c.assType), c.start, c.end)
+	if err != nil {
+		return err
+	}
+	if err = a.RegisterUpdateParentDraw(c.diagram.updateDrawData); err != nil {
+		return err
+	}
+	if err = c.diagram.componentsContainer.Insert(a); err != nil {
+		return err
+	}
+	tmp := c.diagram.associations[stGad]
+	tmp[0] = append(tmp[0], a)
+	c.diagram.associations[stGad] = tmp
+	tmp = c.diagram.associations[enGad]
+	tmp[1] = append(tmp[1], a)
+	c.diagram.associations[enGad] = tmp
+	c.diagram.lastModified = time.Now()
+	c.association = a
+	return c.diagram.updateDrawData()
+}
+
+func (c *addAssociationCommand) Unexecute() duerror.DUError {
+	if c.association == nil {
+		return nil
+	}
+	return c.diagram.removeAssociation(c.association)
+}
+
+// removeComponentsCommand removes a list of components from the diagram.
+type removeComponentsCommand struct {
+	diagram    *UMLDiagram
+	components []component.Component
+}
+
+func (c *removeComponentsCommand) Execute() duerror.DUError {
+	for _, comp := range c.components {
+		switch comp := comp.(type) {
+		case *component.Gadget:
+			if err := c.diagram.removeGadget(comp); err != nil {
+				return err
+			}
+		case *component.Association:
+			if err := c.diagram.removeAssociation(comp); err != nil {
+				return err
+			}
+		}
+	}
+	c.diagram.lastModified = time.Now()
+	return c.diagram.updateDrawData()
+}
+
+func (c *removeComponentsCommand) Unexecute() duerror.DUError {
+	// undo not supported yet
+	return nil
+}
+
+// helper to wrap a function as a command.
+type funcCommand struct {
+	exec func() duerror.DUError
+	undo func() duerror.DUError
+}
+
+func (f *funcCommand) Execute() duerror.DUError {
+	if f.exec != nil {
+		return f.exec()
+	}
+	return nil
+}
+
+func (f *funcCommand) Unexecute() duerror.DUError {
+	if f.undo != nil {
+		return f.undo()
+	}
+	return nil
+}
+
+var _ command.Command = (*addGadgetCommand)(nil)
+var _ command.Command = (*addAssociationCommand)(nil)
+var _ command.Command = (*removeComponentsCommand)(nil)
+var _ command.Command = (*funcCommand)(nil)

--- a/app/backend/umldiagram/commands_test.go
+++ b/app/backend/umldiagram/commands_test.go
@@ -1,0 +1,102 @@
+package umldiagram
+
+import (
+	"testing"
+
+	"Dr.uml/backend/component"
+	"Dr.uml/backend/drawdata"
+	"Dr.uml/backend/utils"
+	"Dr.uml/backend/utils/duerror"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFuncCommand(t *testing.T) {
+	called := false
+	undone := false
+	cmd := &funcCommand{
+		exec: func() duerror.DUError { called = true; return nil },
+		undo: func() duerror.DUError { undone = true; return nil },
+	}
+	assert.NoError(t, cmd.Execute())
+	assert.True(t, called)
+	assert.NoError(t, cmd.Unexecute())
+	assert.True(t, undone)
+}
+
+func TestAddGadgetCommand_ExecuteUnexecute(t *testing.T) {
+	d, err := CreateEmptyUMLDiagram("cmd_test.uml", ClassDiagram)
+	assert.NoError(t, err)
+	prev := d.lastModified
+
+	cmd := &addGadgetCommand{
+		diagram:    d,
+		gadgetType: component.Class,
+		point:      utils.Point{X: 10, Y: 10},
+		layer:      0,
+		color:      drawdata.DefaultGadgetColor,
+		header:     "Header",
+	}
+	err = cmd.Execute()
+	assert.NoError(t, err)
+	l, _ := d.componentsContainer.Len()
+	assert.Equal(t, 1, l)
+	assert.True(t, d.lastModified.After(prev) || d.lastModified.Equal(prev))
+	assert.NotNil(t, cmd.gadget)
+	assert.Len(t, d.associations, 1)
+
+	err = cmd.Unexecute()
+	assert.NoError(t, err)
+	l, _ = d.componentsContainer.Len()
+	assert.Equal(t, 0, l)
+}
+
+func TestAddAssociationCommand_ExecuteUnexecute(t *testing.T) {
+	d, err := CreateEmptyUMLDiagram("ass_cmd_test.uml", ClassDiagram)
+	assert.NoError(t, err)
+
+	// add two gadgets
+	_ = d.AddGadget(component.Class, utils.Point{X: 5, Y: 5}, 0, drawdata.DefaultGadgetColor, "")
+	_ = d.AddGadget(component.Class, utils.Point{X: 100, Y: 100}, 0, drawdata.DefaultGadgetColor, "")
+	gs := d.componentsContainer.GetAll()
+	g1 := gs[0].(*component.Gadget)
+	g2 := gs[1].(*component.Gadget)
+	g1dd := g1.GetDrawData().(drawdata.Gadget)
+	g2dd := g2.GetDrawData().(drawdata.Gadget)
+
+	cmd := &addAssociationCommand{
+		diagram: d,
+		assType: component.Extension,
+		start:   utils.Point{X: g1dd.X + 1, Y: g1dd.Y + 1},
+		end:     utils.Point{X: g2dd.X + 1, Y: g2dd.Y + 1},
+	}
+	prev := d.lastModified
+	err = cmd.Execute()
+	assert.NoError(t, err)
+	l, _ := d.componentsContainer.Len()
+	assert.Equal(t, 3, l) // 2 gadgets + 1 association
+	assert.True(t, d.lastModified.After(prev) || d.lastModified.Equal(prev))
+	assert.NotNil(t, cmd.association)
+
+	err = cmd.Unexecute()
+	assert.NoError(t, err)
+	l, _ = d.componentsContainer.Len()
+	assert.Equal(t, 2, l)
+}
+
+func TestRemoveComponentsCommand(t *testing.T) {
+	d, err := CreateEmptyUMLDiagram("remove_cmd.uml", ClassDiagram)
+	assert.NoError(t, err)
+	_ = d.AddGadget(component.Class, utils.Point{X: 1, Y: 1}, 0, drawdata.DefaultGadgetColor, "")
+	g := d.componentsContainer.GetAll()[0]
+	cmd := &removeComponentsCommand{
+		diagram:    d,
+		components: []component.Component{g},
+	}
+	prev := d.lastModified
+	err = cmd.Execute()
+	assert.NoError(t, err)
+	l, _ := d.componentsContainer.Len()
+	assert.Equal(t, 0, l)
+	assert.True(t, d.lastModified.After(prev) || d.lastModified.Equal(prev))
+	assert.NoError(t, cmd.Unexecute())
+}

--- a/app/backend/umldiagram/umldiagram.go
+++ b/app/backend/umldiagram/umldiagram.go
@@ -340,7 +340,7 @@ func (ud *UMLDiagram) AddAttributeToGadget(section int, content string) duerror.
 
 		cmd := &funcCommand{
 			exec: func() duerror.DUError { return g.AddAttribute(section, content) },
-			undo: func() duerror.DUError { 
+			undo: func() duerror.DUError {
 				if addedIndex >= 0 {
 					return g.RemoveAttribute(section, addedIndex)
 				}

--- a/app/backend/umldiagram/umldiagram_test.go
+++ b/app/backend/umldiagram/umldiagram_test.go
@@ -438,7 +438,7 @@ func TestAttributeOperationsUndoRedo(t *testing.T) {
 
 	attrs := gadget.GetAttributes(1)
 	initialCount := len(attrs)
-	
+
 	// Add new attribute
 	err = diagram.AddAttributeToGadget(1, "test attribute")
 	assert.NoError(t, err)
@@ -460,7 +460,7 @@ func TestAttributeOperationsUndoRedo(t *testing.T) {
 	// Undo content change
 	err = diagram.cmdMgr.Undo()
 	assert.NoError(t, err)
-	
+
 	// Get latest attributes and verify content restored
 	attrs = gadget.GetAttributes(1)
 	assert.Equal(t, "test attribute", attrs[lastIndex].GetContent())
@@ -468,7 +468,7 @@ func TestAttributeOperationsUndoRedo(t *testing.T) {
 	// Redo content change
 	err = diagram.cmdMgr.Redo()
 	assert.NoError(t, err)
-	
+
 	// Get latest attributes and verify content changed again
 	attrs = gadget.GetAttributes(1)
 	assert.Equal(t, "modified content", attrs[lastIndex].GetContent())
@@ -517,7 +517,7 @@ func TestAttributeOperationsUndoRedo(t *testing.T) {
 	// Test gadget point with undo/redo
 	oldPoint := gadget.GetPoint()
 	newPoint := utils.Point{X: 30, Y: 40}
-	
+
 	err = diagram.SetPointGadget(newPoint)
 	assert.NoError(t, err)
 	assert.Equal(t, newPoint, gadget.GetPoint())


### PR DESCRIPTION
Introduce a command pattern to manage component operations in the UML diagram, enhancing the ability to execute, undo, and redo actions. Include unit tests to validate the functionality of the command pattern implementation.