### PR TITLE
[Nuke Backend] Command Pattern

### DIFF
--- a/app/backend/command/manager.go
+++ b/app/backend/command/manager.go
@@ -1,4 +1,73 @@
 package command
 
+import (
+	"time"
+
+	"Dr.uml/backend/utils/duerror"
+)
+
+type Command interface {
+	Execute() duerror.DUError
+	Unexecute() duerror.DUError
+	GetBefore() time.Time
+	GetAfter() time.Time
+}
+
 type Manager struct {
+	undoStack    []Command
+	redoStack    []Command
+	lastModified time.Time
+}
+
+func NewManager(lastModified time.Time) *Manager {
+	return &Manager{
+		undoStack:    make([]Command, 0),
+		redoStack:    make([]Command, 0),
+		lastModified: lastModified,
+	}
+}
+
+func (m *Manager) GetLastModified() time.Time {
+	return m.lastModified
+}
+
+func (m *Manager) Execute(cmd Command) duerror.DUError {
+	if cmd == nil {
+		return duerror.NewInvalidArgumentError("command is nil")
+	}
+	if err := cmd.Execute(); err != nil {
+		return err
+	}
+	m.undoStack = append(m.undoStack, cmd)
+	m.redoStack = nil
+	m.lastModified = cmd.GetAfter()
+	return nil
+}
+
+func (m *Manager) Undo() duerror.DUError {
+	if len(m.undoStack) == 0 {
+		return duerror.NewInvalidArgumentError("no undo command")
+	}
+	cmd := m.undoStack[len(m.undoStack)-1]
+	m.undoStack = m.undoStack[:len(m.undoStack)-1]
+	if err := cmd.Unexecute(); err != nil {
+		return err
+	}
+	m.redoStack = append(m.redoStack, cmd)
+	m.lastModified = cmd.GetBefore()
+	return nil
+}
+
+func (m *Manager) Redo() duerror.DUError {
+	if len(m.redoStack) == 0 {
+		return duerror.NewInvalidArgumentError("no redo command")
+	}
+	cmd := m.redoStack[len(m.redoStack)-1]
+	m.redoStack = m.redoStack[:len(m.redoStack)-1]
+	if err := cmd.Execute(); err != nil {
+		return err
+	}
+	m.undoStack = append(m.undoStack, cmd)
+	m.lastModified = cmd.GetAfter()
+	return nil
 }

--- a/app/backend/command/manager.go
+++ b/app/backend/command/manager.go
@@ -6,6 +6,8 @@ import (
 	"Dr.uml/backend/utils/duerror"
 )
 
+const CMD_LIMIT = 20
+
 type Command interface {
 	Execute() duerror.DUError
 	Unexecute() duerror.DUError
@@ -17,13 +19,15 @@ type Manager struct {
 	undoStack    []Command
 	redoStack    []Command
 	lastModified time.Time
+	limit        int
 }
 
 func NewManager(lastModified time.Time) *Manager {
 	return &Manager{
-		undoStack:    make([]Command, 0),
-		redoStack:    make([]Command, 0),
+		undoStack:    make([]Command, 0, CMD_LIMIT),
+		redoStack:    make([]Command, 0, CMD_LIMIT),
 		lastModified: lastModified,
+		limit:        CMD_LIMIT,
 	}
 }
 
@@ -37,6 +41,9 @@ func (m *Manager) Execute(cmd Command) duerror.DUError {
 	}
 	if err := cmd.Execute(); err != nil {
 		return err
+	}
+	if len(m.undoStack) == m.limit {
+		m.undoStack = m.undoStack[1:]
 	}
 	m.undoStack = append(m.undoStack, cmd)
 	m.redoStack = nil

--- a/app/backend/command/manager_test.go
+++ b/app/backend/command/manager_test.go
@@ -1,0 +1,150 @@
+package command
+
+import (
+	"testing"
+	"time"
+
+	"Dr.uml/backend/utils/duerror"
+	"github.com/stretchr/testify/assert"
+)
+
+// MockCommand implements the Command interface for testing
+type MockCommand struct {
+	before       time.Time
+	after        time.Time
+	executeErr   duerror.DUError
+	unexecuteErr duerror.DUError
+}
+
+func (m *MockCommand) Execute() duerror.DUError   { return m.executeErr }
+func (m *MockCommand) Unexecute() duerror.DUError { return m.unexecuteErr }
+func (m *MockCommand) GetBefore() time.Time       { return m.before }
+func (m *MockCommand) GetAfter() time.Time        { return m.after }
+
+func TestManager_Execute_NilCommand(t *testing.T) {
+	m := NewManager(time.Now())
+	err := m.Execute(nil)
+	assert.NotNil(t, err)
+	assert.Equal(t, "command is nil", err.Error())
+}
+
+func TestManager_Execute_Success(t *testing.T) {
+	before := time.Now()
+	after := before.Add(time.Minute)
+	cmd := &MockCommand{before: before, after: after}
+
+	m := NewManager(before)
+	err := m.Execute(cmd)
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(m.undoStack))
+	assert.Equal(t, 0, len(m.redoStack))
+	assert.Equal(t, after, m.GetLastModified())
+}
+
+func TestManager_Execute_ErrorFromCommand(t *testing.T) {
+	before := time.Now()
+	cmd := &MockCommand{
+		before:     before,
+		after:      before.Add(time.Minute),
+		executeErr: duerror.NewInvalidArgumentError("exec fail"),
+	}
+
+	m := NewManager(before)
+	err := m.Execute(cmd)
+	assert.NotNil(t, err)
+	assert.Equal(t, "exec fail", err.Error())
+	assert.Equal(t, 0, len(m.undoStack))
+}
+
+func TestManager_Undo_NoCommand(t *testing.T) {
+	m := NewManager(time.Now())
+	err := m.Undo()
+	assert.NotNil(t, err)
+	assert.Equal(t, "no undo command", err.Error())
+}
+
+func TestManager_Undo_Success(t *testing.T) {
+	before := time.Now()
+	after := before.Add(time.Minute)
+	cmd := &MockCommand{before: before, after: after}
+
+	m := NewManager(after)
+	m.Execute(cmd)
+	err := m.Undo()
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(m.undoStack))
+	assert.Equal(t, 1, len(m.redoStack))
+	assert.Equal(t, before, m.GetLastModified())
+}
+
+func TestManager_Undo_ErrorFromCommand(t *testing.T) {
+	before := time.Now()
+	after := before.Add(time.Minute)
+	cmd := &MockCommand{
+		before:       before,
+		after:        after,
+		unexecuteErr: duerror.NewInvalidArgumentError("undo fail"),
+	}
+
+	m := NewManager(after)
+	m.Execute(cmd)
+	err := m.Undo()
+	assert.NotNil(t, err)
+	assert.Equal(t, "undo fail", err.Error())
+	assert.Equal(t, 0, len(m.undoStack)) // still popped
+}
+
+func TestManager_Redo_NoCommand(t *testing.T) {
+	m := NewManager(time.Now())
+	err := m.Redo()
+	assert.NotNil(t, err)
+	assert.Equal(t, "no redo command", err.Error())
+}
+
+func TestManager_Redo_Success(t *testing.T) {
+	before := time.Now()
+	after := before.Add(time.Minute)
+	cmd := &MockCommand{before: before, after: after}
+
+	m := NewManager(before)
+	m.Execute(cmd)
+	m.Undo()
+	err := m.Redo()
+	assert.Nil(t, err)
+	assert.Equal(t, 1, len(m.undoStack))
+	assert.Equal(t, 0, len(m.redoStack))
+	assert.Equal(t, after, m.GetLastModified())
+}
+
+func TestManager_Redo_ErrorFromCommand(t *testing.T) {
+	before := time.Now()
+	after := before.Add(time.Minute)
+	cmd := &MockCommand{
+		before:     before,
+		after:      after,
+		executeErr: duerror.NewInvalidArgumentError("redo fail"),
+	}
+
+	m := NewManager(before)
+	m.Execute(cmd)
+	m.Undo()
+	err := m.Redo()
+	assert.NotNil(t, err)
+	assert.Equal(t, "no redo command", err.Error())
+}
+
+func TestManager_StackLimit(t *testing.T) {
+	now := time.Now()
+	m := NewManager(now)
+
+	for i := 0; i < CMD_LIMIT+5; i++ {
+		cmd := &MockCommand{
+			before: now.Add(time.Duration(i) * time.Minute),
+			after:  now.Add(time.Duration(i+1) * time.Minute),
+		}
+		m.Execute(cmd)
+	}
+
+	assert.Equal(t, CMD_LIMIT, len(m.undoStack))
+	assert.Equal(t, 0, len(m.redoStack))
+}

--- a/app/backend/component/association.go
+++ b/app/backend/component/association.go
@@ -62,7 +62,7 @@ func NewAssociation(parents [2]*Gadget, assType AssociationType, stPoint utils.P
 			float64(enPoint.X-enGdd.X) / float64(enGdd.Width),
 			float64(enPoint.Y-enGdd.Y) / float64(enGdd.Height)},
 	}
-	if err := a.updateDrawData(); err != nil {
+	if err := a.UpdateDrawData(); err != nil {
 		return nil, err
 	}
 	return a, nil
@@ -225,7 +225,7 @@ func (ass *Association) SetParentStart(gadget *Gadget, point utils.Point) duerro
 	}
 	ass.startPointRatio[0] = float64(point.X-gdd.X) / float64(gdd.Width)
 	ass.startPointRatio[1] = float64(point.Y-gdd.Y) / float64(gdd.Height)
-	return ass.updateDrawData()
+	return ass.UpdateDrawData()
 }
 
 func (ass *Association) SetParentEnd(gadget *Gadget, point utils.Point) duerror.DUError {
@@ -240,7 +240,7 @@ func (ass *Association) SetParentEnd(gadget *Gadget, point utils.Point) duerror.
 	}
 	ass.endPointRatio[0] = float64(point.X-gdd.X) / float64(gdd.Width)
 	ass.endPointRatio[1] = float64(point.Y-gdd.Y) / float64(gdd.Height)
-	return ass.updateDrawData()
+	return ass.UpdateDrawData()
 }
 
 func (ass *Association) SetAttrContent(index int, content string) duerror.DUError {
@@ -250,7 +250,7 @@ func (ass *Association) SetAttrContent(index int, content string) duerror.DUErro
 	if err := ass.attributes[index].SetContent(content); err != nil {
 		return err
 	}
-	return ass.updateDrawData()
+	return ass.UpdateDrawData()
 }
 
 func (ass *Association) SetAttrSize(index int, size int) duerror.DUError {
@@ -260,7 +260,7 @@ func (ass *Association) SetAttrSize(index int, size int) duerror.DUError {
 	if err := ass.attributes[index].SetSize(size); err != nil {
 		return err
 	}
-	return ass.updateDrawData()
+	return ass.UpdateDrawData()
 }
 
 func (ass *Association) SetAttrStyle(index int, style int) duerror.DUError {
@@ -270,7 +270,7 @@ func (ass *Association) SetAttrStyle(index int, style int) duerror.DUError {
 	if err := ass.attributes[index].SetStyle(attribute.Textstyle(style)); err != nil {
 		return err
 	}
-	return ass.updateDrawData()
+	return ass.UpdateDrawData()
 }
 
 func (ass *Association) SetAttrFontFile(index int, fontFile string) duerror.DUError {
@@ -280,7 +280,7 @@ func (ass *Association) SetAttrFontFile(index int, fontFile string) duerror.DUEr
 	if err := ass.attributes[index].SetFontFile(fontFile); err != nil {
 		return err
 	}
-	return ass.updateDrawData()
+	return ass.UpdateDrawData()
 }
 
 func (ass *Association) SetAttrRatio(index int, ratio float64) duerror.DUError {
@@ -290,7 +290,7 @@ func (ass *Association) SetAttrRatio(index int, ratio float64) duerror.DUError {
 	if err := ass.attributes[index].SetRatio(ratio); err != nil {
 		return err
 	}
-	return ass.updateDrawData()
+	return ass.UpdateDrawData()
 }
 
 // Other methods
@@ -316,15 +316,15 @@ func (ass *Association) AddAttribute(ratio float64, content string) duerror.DUEr
 	if err != nil {
 		return err
 	}
-	att.RegisterUpdateParentDraw(ass.updateDrawData)
+	att.RegisterUpdateParentDraw(ass.UpdateDrawData)
 	ass.attributes = append(ass.attributes, att)
-	return ass.updateDrawData()
+	return ass.UpdateDrawData()
 }
 
 func (ass *Association) AddLoadedAttribute(att *attribute.AssAttribute) duerror.DUError {
-	att.RegisterUpdateParentDraw(ass.updateDrawData)
+	att.RegisterUpdateParentDraw(ass.UpdateDrawData)
 	ass.attributes = append(ass.attributes, att)
-	return ass.updateDrawData()
+	return ass.UpdateDrawData()
 }
 
 func (ass *Association) MoveAttribute(index int, ratio float64) duerror.DUError {
@@ -339,10 +339,10 @@ func (ass *Association) RemoveAttribute(index int) duerror.DUError {
 		return duerror.NewInvalidArgumentError("index out of range")
 	}
 	ass.attributes = append(ass.attributes[:index], ass.attributes[index+1:]...)
-	return ass.updateDrawData()
+	return ass.UpdateDrawData()
 }
 
-func (ass *Association) updateDrawData() duerror.DUError {
+func (ass *Association) UpdateDrawData() duerror.DUError {
 	if ass == nil || ass.parents[0] == nil || ass.parents[1] == nil {
 		return duerror.NewInvalidArgumentError("association or parents are nil")
 	}

--- a/app/backend/component/association_test.go
+++ b/app/backend/component/association_test.go
@@ -135,7 +135,7 @@ func Test_Association_AddAttribute(t *testing.T) {
 	content := "test attribute"
 	var att *attribute.AssAttribute
 	t.Run("Add Attribute", func(t *testing.T) {
-		err := ass.AddAttribute(ratio, content)
+		err := ass.AddAttribute(-1, ratio, content)
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}

--- a/app/backend/component/association_test.go
+++ b/app/backend/component/association_test.go
@@ -247,7 +247,7 @@ func Test_Association_UpdateDrawData(t *testing.T) {
 	}
 
 	t.Run("Update with valid data", func(t *testing.T) {
-		err := ass.updateDrawData()
+		err := ass.UpdateDrawData()
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}

--- a/app/backend/component/association_test.go
+++ b/app/backend/component/association_test.go
@@ -101,7 +101,7 @@ func Test_Association_Setters(t *testing.T) {
 		newStPoint := utils.Point{X: 2, Y: 2}
 		newSt := newEmptyGadget(Class, newStPoint)
 
-		err := ass.SetParentStart(newSt, newStPoint)
+		err := ass.SetParentStart(newSt, [2]float64{0, 0})
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
@@ -114,7 +114,7 @@ func Test_Association_Setters(t *testing.T) {
 		newEnPoint := utils.Point{X: 4, Y: 4}
 		newEn := newEmptyGadget(Class, newEnPoint)
 
-		err := ass.SetParentEnd(newEn, newEnPoint)
+		err := ass.SetParentEnd(newEn, [2]float64{0, 0})
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}

--- a/app/backend/component/attribute/AssAttribute.go
+++ b/app/backend/component/attribute/AssAttribute.go
@@ -29,10 +29,10 @@ func NewAssAttribute(ratio float64, content string) (*AssAttribute, duerror.DUEr
 		ratio:     ratio,
 	}
 	att.Attribute.RegisterUpdateParentDraw(func() duerror.DUError {
-		att.UpdateDrawData()
+		att.updateDrawData()
 		return nil
 	})
-	att.UpdateDrawData()
+	att.updateDrawData()
 	return att, nil
 }
 
@@ -46,7 +46,7 @@ func FromSavedAssAttribute(savedAssAtt utils.SavedAtt) (*AssAttribute, duerror.D
 		},
 		ratio: savedAssAtt.Ratio,
 	}
-	ass.UpdateDrawData()
+	ass.updateDrawData()
 	return ass, nil
 }
 
@@ -76,11 +76,11 @@ func (att *AssAttribute) SetRatio(ratio float64) duerror.DUError {
 		return duerror.NewInvalidArgumentError("ratio should be between 0 and 1")
 	}
 	att.ratio = ratio
-	att.UpdateDrawData()
+	att.updateDrawData()
 	return nil
 }
 
-func (att *AssAttribute) UpdateDrawData() {
+func (att *AssAttribute) updateDrawData() {
 	att.assDD.Content = att.content
 	att.assDD.FontSize = att.size
 	att.assDD.FontStyle = int(att.style)

--- a/app/backend/component/attribute/AssAttribute.go
+++ b/app/backend/component/attribute/AssAttribute.go
@@ -29,22 +29,24 @@ func NewAssAttribute(ratio float64, content string) (*AssAttribute, duerror.DUEr
 		ratio:     ratio,
 	}
 	att.Attribute.RegisterUpdateParentDraw(func() duerror.DUError {
-		att.updateDrawData()
+		att.UpdateDrawData()
 		return nil
 	})
-	att.updateDrawData()
+	att.UpdateDrawData()
 	return att, nil
 }
 
-func FromSavedAssAttributes(savedAssAtt utils.SavedAtt) (*AssAttribute, duerror.DUError) {
-	ass, err := NewAssAttribute(savedAssAtt.Ratio, savedAssAtt.Content)
-	if err != nil {
-		return nil, err
+func FromSavedAssAttribute(savedAssAtt utils.SavedAtt) (*AssAttribute, duerror.DUError) {
+	ass := &AssAttribute{
+		Attribute: Attribute{
+			content:  savedAssAtt.Content,
+			size:     savedAssAtt.Size,
+			style:    Textstyle(savedAssAtt.Style),
+			fontFile: savedAssAtt.FontFile,
+		},
+		ratio: savedAssAtt.Ratio,
 	}
-	ass.SetSize(savedAssAtt.Size)
-	ass.SetStyle(Textstyle(savedAssAtt.Style))
-	ass.SetFontFile(savedAssAtt.FontFile)
-
+	ass.UpdateDrawData()
 	return ass, nil
 }
 
@@ -74,11 +76,11 @@ func (att *AssAttribute) SetRatio(ratio float64) duerror.DUError {
 		return duerror.NewInvalidArgumentError("ratio should be between 0 and 1")
 	}
 	att.ratio = ratio
-	att.updateDrawData()
+	att.UpdateDrawData()
 	return nil
 }
 
-func (att *AssAttribute) updateDrawData() {
+func (att *AssAttribute) UpdateDrawData() {
 	att.assDD.Content = att.content
 	att.assDD.FontSize = att.size
 	att.assDD.FontStyle = int(att.style)

--- a/app/backend/component/component.go
+++ b/app/backend/component/component.go
@@ -11,6 +11,7 @@ type Component interface {
 	// Copy() (Component, duerror.DUError)
 	Cover(p utils.Point) (bool, duerror.DUError)
 	GetLayer() int
+	GetIsSelected() bool
 	SetLayer(layer int) duerror.DUError
 	SetIsSelected(isSelected bool) duerror.DUError
 	GetDrawData() any

--- a/app/backend/component/gadget_test.go
+++ b/app/backend/component/gadget_test.go
@@ -150,7 +150,7 @@ func TestSetAttrContent(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Add an attribute to test
-	assert.NoError(t, g.AddAttribute(0, "test"))
+	assert.NoError(t, g.AddAttribute(0, -1, "test"))
 
 	// Test valid case
 	assert.NoError(t, g.SetAttrContent(0, 0, "updated"))
@@ -174,7 +174,7 @@ func TestSetAttrSize(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Add an attribute to test
-	assert.NoError(t, g.AddAttribute(0, "test"))
+	assert.NoError(t, g.AddAttribute(0, -1, "test"))
 
 	// Test valid case
 	assert.NoError(t, g.SetAttrSize(0, 0, 16))
@@ -197,7 +197,7 @@ func TestSetAttrStyle(t *testing.T) {
 	err := g.RegisterUpdateParentDraw(mp.UpdateParentDraw)
 	assert.NoError(t, err)
 	// Add an attribute to test
-	assert.NoError(t, g.AddAttribute(0, "test"))
+	assert.NoError(t, g.AddAttribute(0, -1, "test"))
 
 	// Test valid cases
 	assert.NoError(t, g.SetAttrStyle(0, 0, int(attribute.Bold)))
@@ -265,9 +265,9 @@ func TestAddAttribute(t *testing.T) {
 	initialLengths := g.GetAttributesLen()
 
 	// Test adding attributes to different sections
-	assert.NoError(t, g.AddAttribute(0, "test0"))
-	assert.NoError(t, g.AddAttribute(1, "test1"))
-	assert.NoError(t, g.AddAttribute(2, "test2"))
+	assert.NoError(t, g.AddAttribute(0, -1, "test0"))
+	assert.NoError(t, g.AddAttribute(1, -1, "test1"))
+	assert.NoError(t, g.AddAttribute(2, -1, "test2"))
 
 	// Verify lengths increased
 	newLengths := g.GetAttributesLen()
@@ -276,17 +276,17 @@ func TestAddAttribute(t *testing.T) {
 	}
 
 	// Test invalid section
-	assert.Error(t, g.AddAttribute(-1, "invalid"))
-	assert.Error(t, g.AddAttribute(len(g.attributes), "invalid"))
+	assert.Error(t, g.AddAttribute(-1, -1, "invalid"))
+	assert.Error(t, g.AddAttribute(len(g.attributes), -1, "invalid"))
 
 	// Test with parent draw update
-	assert.NoError(t, g.AddAttribute(0, "test with parent"))
+	assert.NoError(t, g.AddAttribute(0, -1, "test with parent"))
 	assert.Equal(t, 4, mp.Times)
 
 	// Test with invalid content (this depends on attribute.NewAttribute implementation)
 	// We can't easily test this without knowing what makes content invalid
 	// But we can at least call it with empty string to see if it works
-	assert.NoError(t, g.AddAttribute(0, ""))
+	assert.NoError(t, g.AddAttribute(0, -1, ""))
 }
 
 func TestRemoveAttribute(t *testing.T) {
@@ -296,9 +296,9 @@ func TestRemoveAttribute(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Add attributes to test removal
-	assert.NoError(t, g.AddAttribute(0, "test0"))
-	assert.NoError(t, g.AddAttribute(0, "test1"))
-	assert.NoError(t, g.AddAttribute(1, "test2"))
+	assert.NoError(t, g.AddAttribute(0, -1, "test0"))
+	assert.NoError(t, g.AddAttribute(0, -1, "test1"))
+	assert.NoError(t, g.AddAttribute(1, -1, "test2"))
 
 	// Get lengths before removal
 	beforeLengths := g.GetAttributesLen()
@@ -372,7 +372,7 @@ func TestRegisterUpdateParentDraw(t *testing.T) {
 	assert.NoError(t, g.RegisterUpdateParentDraw(mp.UpdateParentDraw))
 	assert.Equal(t, 0, mp.Times)
 
-	assert.NoError(t, g.AddAttribute(0, "test"))
+	assert.NoError(t, g.AddAttribute(0, -1, "test"))
 	assert.Equal(t, 1, mp.Times)
 
 	// nil function

--- a/app/backend/components/container.go
+++ b/app/backend/components/container.go
@@ -11,6 +11,7 @@ type Container interface {
 	Remove(c component.Component) duerror.DUError
 	Search(p utils.Point) (component.Component, duerror.DUError)
 	SearchGadget(p utils.Point) (*component.Gadget, duerror.DUError)
+	Contain(c component.Component) bool
 	GetAll() []component.Component
 	Len() int
 }

--- a/app/backend/components/containerMap.go
+++ b/app/backend/components/containerMap.go
@@ -78,6 +78,11 @@ func (cp *containerMap) SearchGadget(p utils.Point) (*component.Gadget, duerror.
 	return candidate, nil
 }
 
+func (cp *containerMap) Contain(c component.Component) bool {
+	_, ok := cp.compMap[c]
+	return ok
+}
+
 func (cp *containerMap) GetAll() []component.Component {
 	return slices.Collect(maps.Keys(cp.compMap))
 }

--- a/app/backend/mocks/component.go
+++ b/app/backend/mocks/component.go
@@ -64,6 +64,20 @@ func (mr *MockComponentMockRecorder) GetDrawData() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDrawData", reflect.TypeOf((*MockComponent)(nil).GetDrawData))
 }
 
+// GetIsSelected mocks base method.
+func (m *MockComponent) GetIsSelected() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIsSelected")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// GetIsSelected indicates an expected call of GetIsSelected.
+func (mr *MockComponentMockRecorder) GetIsSelected() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIsSelected", reflect.TypeOf((*MockComponent)(nil).GetIsSelected))
+}
+
 // GetLayer mocks base method.
 func (m *MockComponent) GetLayer() int {
 	m.ctrl.T.Helper()

--- a/app/backend/umldiagram/commands.go
+++ b/app/backend/umldiagram/commands.go
@@ -95,3 +95,37 @@ func (cmd *moveGadgetCommand) Execute() duerror.DUError {
 func (cmd *moveGadgetCommand) Unexecute() duerror.DUError {
 	return cmd.diagram.moveGadget(cmd.gadget, cmd.oldPoint)
 }
+
+// set parent association
+type setParentCommand struct {
+	baseCommand
+	association *component.Association
+	stNew       *component.Gadget
+	enNew       *component.Gadget
+	stOld       *component.Gadget
+	enOld       *component.Gadget
+	stRatioNew  [2]float64
+	enRatioNew  [2]float64
+	stRatioOld  [2]float64
+	enRatioOld  [2]float64
+}
+
+func (cmd *setParentCommand) Execute() duerror.DUError {
+	return cmd.diagram.updateAssociationParent(
+		cmd.association,
+		cmd.stNew,
+		cmd.enNew,
+		cmd.stRatioNew,
+		cmd.enRatioNew,
+	)
+}
+
+func (cmd *setParentCommand) Unexecute() duerror.DUError {
+	return cmd.diagram.updateAssociationParent(
+		cmd.association,
+		cmd.stOld,
+		cmd.enOld,
+		cmd.stRatioOld,
+		cmd.enRatioOld,
+	)
+}

--- a/app/backend/umldiagram/commands.go
+++ b/app/backend/umldiagram/commands.go
@@ -146,3 +146,102 @@ func (cmd *setParentEndCommand) Unexecute() duerror.DUError {
 		cmd.enRatioOld,
 	)
 }
+
+// add/remove attribute
+type addAttributeGadgetCommand struct {
+	baseCommand
+	gadget  *component.Gadget
+	content string
+	section int
+	index   int
+}
+
+func (cmd *addAttributeGadgetCommand) Execute() duerror.DUError {
+	return cmd.diagram.addAttributeGadget(
+		cmd.gadget,
+		cmd.section,
+		cmd.index,
+		cmd.content,
+	)
+}
+
+func (cmd *addAttributeGadgetCommand) Unexecute() duerror.DUError {
+	return cmd.diagram.removeAttributeGadget(
+		cmd.gadget,
+		cmd.section,
+		cmd.index,
+	)
+}
+
+type removeAttributeGadgetCommand struct {
+	baseCommand
+	gadget  *component.Gadget
+	content string
+	section int
+	index   int
+}
+
+func (cmd *removeAttributeGadgetCommand) Execute() duerror.DUError {
+	return cmd.diagram.removeAttributeGadget(
+		cmd.gadget,
+		cmd.section,
+		cmd.index,
+	)
+}
+
+func (cmd *removeAttributeGadgetCommand) Unexecute() duerror.DUError {
+	return cmd.diagram.addAttributeGadget(
+		cmd.gadget,
+		cmd.section,
+		cmd.index,
+		cmd.content,
+	)
+}
+
+type addAttributeAssociationCommand struct {
+	baseCommand
+	association *component.Association
+	content     string
+	ratio       float64
+	index       int
+}
+
+func (cmd *addAttributeAssociationCommand) Execute() duerror.DUError {
+	return cmd.diagram.addAttributeAssociation(
+		cmd.association,
+		cmd.index,
+		cmd.ratio,
+		cmd.content,
+	)
+}
+
+func (cmd *addAttributeAssociationCommand) Unexecute() duerror.DUError {
+	return cmd.diagram.removeAttributeAssociation(
+		cmd.association,
+		cmd.index,
+	)
+}
+
+type removeAttributeAssociationCommand struct {
+	baseCommand
+	association *component.Association
+	content     string
+	ratio       float64
+	index       int
+}
+
+func (cmd *removeAttributeAssociationCommand) Execute() duerror.DUError {
+	return cmd.diagram.removeAttributeAssociation(
+		cmd.association,
+		cmd.index,
+	)
+}
+
+func (cmd *removeAttributeAssociationCommand) Unexecute() duerror.DUError {
+	return cmd.diagram.addAttributeAssociation(
+		cmd.association,
+		cmd.index,
+		cmd.ratio,
+		cmd.content,
+	)
+}

--- a/app/backend/umldiagram/commands.go
+++ b/app/backend/umldiagram/commands.go
@@ -97,35 +97,52 @@ func (cmd *moveGadgetCommand) Unexecute() duerror.DUError {
 }
 
 // set parent association
-type setParentCommand struct {
+type setParentStartCommand struct {
 	baseCommand
 	association *component.Association
 	stNew       *component.Gadget
-	enNew       *component.Gadget
 	stOld       *component.Gadget
-	enOld       *component.Gadget
 	stRatioNew  [2]float64
-	enRatioNew  [2]float64
 	stRatioOld  [2]float64
+}
+
+func (cmd *setParentStartCommand) Execute() duerror.DUError {
+	return cmd.diagram.setAssociationParentStart(
+		cmd.association,
+		cmd.stNew,
+		cmd.stRatioNew,
+	)
+}
+
+func (cmd *setParentStartCommand) Unexecute() duerror.DUError {
+	return cmd.diagram.setAssociationParentStart(
+		cmd.association,
+		cmd.stOld,
+		cmd.stRatioOld,
+	)
+}
+
+type setParentEndCommand struct {
+	baseCommand
+	association *component.Association
+	enNew       *component.Gadget
+	enOld       *component.Gadget
+	enRatioNew  [2]float64
 	enRatioOld  [2]float64
 }
 
-func (cmd *setParentCommand) Execute() duerror.DUError {
-	return cmd.diagram.updateAssociationParent(
+func (cmd *setParentEndCommand) Execute() duerror.DUError {
+	return cmd.diagram.updateAssociationParentEnd(
 		cmd.association,
-		cmd.stNew,
 		cmd.enNew,
-		cmd.stRatioNew,
 		cmd.enRatioNew,
 	)
 }
 
-func (cmd *setParentCommand) Unexecute() duerror.DUError {
-	return cmd.diagram.updateAssociationParent(
+func (cmd *setParentEndCommand) Unexecute() duerror.DUError {
+	return cmd.diagram.updateAssociationParentEnd(
 		cmd.association,
-		cmd.stOld,
 		cmd.enOld,
-		cmd.stRatioOld,
 		cmd.enRatioOld,
 	)
 }

--- a/app/backend/umldiagram/commands.go
+++ b/app/backend/umldiagram/commands.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"Dr.uml/backend/component"
+	"Dr.uml/backend/utils"
 	"Dr.uml/backend/utils/duerror"
 )
 
@@ -63,18 +64,34 @@ func (cmd *selectAllCommand) Unexecute() duerror.DUError {
 	return cmd.diagram.selectAll(cmd.components, !cmd.newValue)
 }
 
-// component setters
-type componentSetterCommand struct {
+// simple setters
+type setterCommand struct {
 	baseCommand
 	component component.Component
 	execute   func() duerror.DUError
 	unexecute func() duerror.DUError
 }
 
-func (cmd *componentSetterCommand) Execute() duerror.DUError {
+func (cmd *setterCommand) Execute() duerror.DUError {
 	return cmd.execute()
 }
 
-func (cmd *componentSetterCommand) Unexecute() duerror.DUError {
+func (cmd *setterCommand) Unexecute() duerror.DUError {
 	return cmd.unexecute()
+}
+
+// move gadget
+type moveGadgetCommand struct {
+	baseCommand
+	gadget   *component.Gadget
+	newPoint utils.Point
+	oldPoint utils.Point
+}
+
+func (cmd *moveGadgetCommand) Execute() duerror.DUError {
+	return cmd.diagram.moveGadget(cmd.gadget, cmd.newPoint)
+}
+
+func (cmd *moveGadgetCommand) Unexecute() duerror.DUError {
+	return cmd.diagram.moveGadget(cmd.gadget, cmd.oldPoint)
 }

--- a/app/backend/umldiagram/commands.go
+++ b/app/backend/umldiagram/commands.go
@@ -107,7 +107,7 @@ type setParentStartCommand struct {
 }
 
 func (cmd *setParentStartCommand) Execute() duerror.DUError {
-	return cmd.diagram.setAssociationParentStart(
+	return cmd.diagram.setParentStartAssociation(
 		cmd.association,
 		cmd.stNew,
 		cmd.stRatioNew,
@@ -115,7 +115,7 @@ func (cmd *setParentStartCommand) Execute() duerror.DUError {
 }
 
 func (cmd *setParentStartCommand) Unexecute() duerror.DUError {
-	return cmd.diagram.setAssociationParentStart(
+	return cmd.diagram.setParentStartAssociation(
 		cmd.association,
 		cmd.stOld,
 		cmd.stRatioOld,
@@ -132,7 +132,7 @@ type setParentEndCommand struct {
 }
 
 func (cmd *setParentEndCommand) Execute() duerror.DUError {
-	return cmd.diagram.updateAssociationParentEnd(
+	return cmd.diagram.setParentEndAssociation(
 		cmd.association,
 		cmd.enNew,
 		cmd.enRatioNew,
@@ -140,7 +140,7 @@ func (cmd *setParentEndCommand) Execute() duerror.DUError {
 }
 
 func (cmd *setParentEndCommand) Unexecute() duerror.DUError {
-	return cmd.diagram.updateAssociationParentEnd(
+	return cmd.diagram.setParentEndAssociation(
 		cmd.association,
 		cmd.enOld,
 		cmd.enRatioOld,

--- a/app/backend/umldiagram/commands.go
+++ b/app/backend/umldiagram/commands.go
@@ -1,0 +1,50 @@
+package umldiagram
+
+import (
+	"time"
+
+	"Dr.uml/backend/component"
+	"Dr.uml/backend/utils/duerror"
+)
+
+type baseCommand struct {
+	diagram *UMLDiagram
+	before  time.Time
+	after   time.Time
+}
+
+func (cmd *baseCommand) GetBefore() time.Time {
+	return cmd.before
+}
+
+func (cmd *baseCommand) GetAfter() time.Time {
+	return cmd.after
+}
+
+// add component
+type addComponentCommand struct {
+	baseCommand
+	component component.Component
+}
+
+func (cmd *addComponentCommand) Execute() duerror.DUError {
+	return cmd.diagram.addComponent(cmd.component)
+}
+
+func (cmd *addComponentCommand) Unexecute() duerror.DUError {
+	return cmd.diagram.removeComponent(cmd.component)
+}
+
+// select
+type removeSelectedComponentCommand struct {
+	baseCommand
+	components map[component.Component]bool
+}
+
+func (cmd *removeSelectedComponentCommand) Execute() duerror.DUError {
+	return cmd.diagram.removeComponents(cmd.components)
+}
+
+func (cmd *removeSelectedComponentCommand) Unexecute() duerror.DUError {
+	return cmd.diagram.addComponents(cmd.components)
+}

--- a/app/backend/umldiagram/commands.go
+++ b/app/backend/umldiagram/commands.go
@@ -48,3 +48,33 @@ func (cmd *removeSelectedComponentCommand) Execute() duerror.DUError {
 func (cmd *removeSelectedComponentCommand) Unexecute() duerror.DUError {
 	return cmd.diagram.addComponents(cmd.components)
 }
+
+type selectAllCommand struct {
+	baseCommand
+	components map[component.Component]bool
+	newValue   bool
+}
+
+func (cmd *selectAllCommand) Execute() duerror.DUError {
+	return cmd.diagram.selectAll(cmd.components, cmd.newValue)
+}
+
+func (cmd *selectAllCommand) Unexecute() duerror.DUError {
+	return cmd.diagram.selectAll(cmd.components, !cmd.newValue)
+}
+
+// component setters
+type componentSetterCommand struct {
+	baseCommand
+	component component.Component
+	execute   func() duerror.DUError
+	unexecute func() duerror.DUError
+}
+
+func (cmd *componentSetterCommand) Execute() duerror.DUError {
+	return cmd.execute()
+}
+
+func (cmd *componentSetterCommand) Unexecute() duerror.DUError {
+	return cmd.unexecute()
+}

--- a/app/backend/umldiagram/umldiagram.go
+++ b/app/backend/umldiagram/umldiagram.go
@@ -201,14 +201,37 @@ func (ud *UMLDiagram) SetAttrContentComponent(section int, index int, content st
 		return err
 	}
 
+	var setContent func(content string) duerror.DUError
+	var oldContent string
 	switch c := c.(type) {
 	case *component.Gadget:
-		return c.SetAttrContent(section, index, content)
+		oldContent = c.GetDrawData().(drawdata.Gadget).Attributes[section][index].Content
+		setContent = func(content string) duerror.DUError {
+			return c.SetAttrContent(section, index, content)
+		}
 	case *component.Association:
-		return c.SetAttrContent(index, content)
+		oldContent = c.GetDrawData().(drawdata.Association).Attributes[index].Content
+		setContent = func(content string) duerror.DUError {
+			return c.SetAttrContent(index, content)
+		}
 	default:
 		return duerror.NewInvalidArgumentError("invalid selected component")
 	}
+
+	cmd := &setterCommand{
+		baseCommand: baseCommand{
+			diagram: ud,
+			before:  ud.GetLastModified(),
+			after:   time.Now(),
+		},
+		component: c,
+		execute:   func() duerror.DUError { return setContent(content) },
+		unexecute: func() duerror.DUError { return setContent(oldContent) },
+	}
+	if err := ud.cmdManager.Execute(cmd); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (ud *UMLDiagram) SetAttrSizeComponent(section int, index int, size int) duerror.DUError {
@@ -217,14 +240,37 @@ func (ud *UMLDiagram) SetAttrSizeComponent(section int, index int, size int) due
 		return err
 	}
 
+	var setSize func(size int) duerror.DUError
+	var oldSize int
 	switch c := c.(type) {
 	case *component.Gadget:
-		return c.SetAttrSize(section, index, size)
+		oldSize = c.GetDrawData().(drawdata.Gadget).Attributes[section][index].FontSize
+		setSize = func(size int) duerror.DUError {
+			return c.SetAttrSize(section, index, size)
+		}
 	case *component.Association:
-		return c.SetAttrSize(index, size)
+		oldSize = c.GetDrawData().(drawdata.Association).Attributes[index].FontSize
+		setSize = func(size int) duerror.DUError {
+			return c.SetAttrSize(index, size)
+		}
 	default:
 		return duerror.NewInvalidArgumentError("invalid selected component")
 	}
+
+	cmd := &setterCommand{
+		baseCommand: baseCommand{
+			diagram: ud,
+			before:  ud.GetLastModified(),
+			after:   time.Now(),
+		},
+		component: c,
+		execute:   func() duerror.DUError { return setSize(size) },
+		unexecute: func() duerror.DUError { return setSize(oldSize) },
+	}
+	if err := ud.cmdManager.Execute(cmd); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (ud *UMLDiagram) SetAttrStyleComponent(section int, index int, style int) duerror.DUError {
@@ -233,14 +279,37 @@ func (ud *UMLDiagram) SetAttrStyleComponent(section int, index int, style int) d
 		return err
 	}
 
+	var setStyle func(style int) duerror.DUError
+	var oldStyle int
 	switch c := c.(type) {
 	case *component.Gadget:
-		return c.SetAttrStyle(section, index, style)
+		oldStyle = c.GetDrawData().(drawdata.Gadget).Attributes[section][index].FontStyle
+		setStyle = func(style int) duerror.DUError {
+			return c.SetAttrStyle(section, index, style)
+		}
 	case *component.Association:
-		return c.SetAttrStyle(index, style)
+		oldStyle = c.GetDrawData().(drawdata.Association).Attributes[index].FontStyle
+		setStyle = func(style int) duerror.DUError {
+			return c.SetAttrStyle(index, style)
+		}
 	default:
 		return duerror.NewInvalidArgumentError("invalid selected component")
 	}
+
+	cmd := &setterCommand{
+		baseCommand: baseCommand{
+			diagram: ud,
+			before:  ud.GetLastModified(),
+			after:   time.Now(),
+		},
+		component: c,
+		execute:   func() duerror.DUError { return setStyle(style) },
+		unexecute: func() duerror.DUError { return setStyle(oldStyle) },
+	}
+	if err := ud.cmdManager.Execute(cmd); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (ud *UMLDiagram) SetAttrFontComponent(section int, index int, fontFile string) duerror.DUError {
@@ -248,14 +317,38 @@ func (ud *UMLDiagram) SetAttrFontComponent(section int, index int, fontFile stri
 	if err != nil {
 		return err
 	}
+
+	var setFont func(font string) duerror.DUError
+	var oldFontFile string
 	switch c := c.(type) {
 	case *component.Gadget:
-		return c.SetAttrFontFile(section, index, fontFile)
+		oldFontFile = c.GetDrawData().(drawdata.Gadget).Attributes[section][index].FontFile
+		setFont = func(font string) duerror.DUError {
+			return c.SetAttrFontFile(section, index, font)
+		}
 	case *component.Association:
-		return c.SetAttrFontFile(index, fontFile)
+		oldFontFile = c.GetDrawData().(drawdata.Association).Attributes[index].FontFile
+		setFont = func(font string) duerror.DUError {
+			return c.SetAttrFontFile(index, font)
+		}
 	default:
 		return duerror.NewInvalidArgumentError("invalid selected component")
 	}
+
+	cmd := &setterCommand{
+		baseCommand: baseCommand{
+			diagram: ud,
+			before:  ud.GetLastModified(),
+			after:   time.Now(),
+		},
+		component: c,
+		execute:   func() duerror.DUError { return setFont(fontFile) },
+		unexecute: func() duerror.DUError { return setFont(oldFontFile) },
+	}
+	if err := ud.cmdManager.Execute(cmd); err != nil {
+		return err
+	}
+	return nil
 }
 
 func (ud *UMLDiagram) SetAttrRatioComponent(section int, index int, ratio float64) duerror.DUError {

--- a/app/backend/umldiagram/umldiagram.go
+++ b/app/backend/umldiagram/umldiagram.go
@@ -965,7 +965,7 @@ func (ud *UMLDiagram) moveGadget(g *component.Gadget, point utils.Point) duerror
 	return nil
 }
 
-func (ud *UMLDiagram) setAssociationParentStart(a *component.Association, stNew *component.Gadget, stRatio [2]float64) duerror.DUError {
+func (ud *UMLDiagram) setParentStartAssociation(a *component.Association, stNew *component.Gadget, stRatio [2]float64) duerror.DUError {
 	stOld := a.GetParentStart()
 	if err := a.SetParentStart(stNew, stRatio); err != nil {
 		return err
@@ -987,7 +987,7 @@ func (ud *UMLDiagram) setAssociationParentStart(a *component.Association, stNew 
 	return nil
 }
 
-func (ud *UMLDiagram) updateAssociationParentEnd(a *component.Association, enNew *component.Gadget, enRatio [2]float64) duerror.DUError {
+func (ud *UMLDiagram) setParentEndAssociation(a *component.Association, enNew *component.Gadget, enRatio [2]float64) duerror.DUError {
 	enOld := a.GetParentEnd()
 	if err := a.SetParentEnd(enNew, enRatio); err != nil {
 		return err

--- a/app/backend/umldiagram/umldiagram.go
+++ b/app/backend/umldiagram/umldiagram.go
@@ -636,7 +636,7 @@ func (ud *UMLDiagram) loadAssAttributes(ass *component.Association, attributes [
 		return duerror.NewInvalidArgumentError("UR loading attributes to a nil ass"), 0
 	}
 	for index, savedAtt := range attributes {
-		newAtt, err := attribute.FromSavedAssAttributes(savedAtt)
+		newAtt, err := attribute.FromSavedAssAttribute(savedAtt)
 		if err != nil {
 			return err, index
 		}

--- a/app/backend/umldiagram/umldiagram_test.go
+++ b/app/backend/umldiagram/umldiagram_test.go
@@ -1348,3 +1348,80 @@ func CMD_MOVE_GADGET(t *testing.T) {
 		}
 	})
 }
+
+func CMD_SET_PARENT(t *testing.T) {
+	d, _ := CreateEmptyUMLDiagram("test.uml", ClassDiagram)
+
+	gadPoint0 := utils.Point{X: 0, Y: 0}
+	gadPoint1 := utils.Point{X: 200, Y: 200}
+	gadPoint2 := utils.Point{X: 400, Y: 400}
+	header0 := "test gadget0"
+	header1 := "test gadget1"
+	header2 := "test gadget2"
+	d.AddGadget(component.Class, gadPoint0, 0, drawdata.DefaultGadgetColor, header0)
+	d.AddGadget(component.Class, gadPoint1, 0, drawdata.DefaultGadgetColor, header1)
+	d.AddGadget(component.Class, gadPoint2, 0, drawdata.DefaultGadgetColor, header2)
+
+	assType0 := component.Composition
+	d.StartAddAssociation(gadPoint0)
+	d.EndAddAssociation(component.AssociationType(assType0), gadPoint1)
+
+	midPoint := utils.Point{
+		X: (gadPoint0.X + gadPoint1.X) / 2,
+		Y: (gadPoint0.Y + gadPoint1.Y) / 2,
+	}
+	d.SelectComponent(midPoint)
+	c, _ := d.componentsContainer.Search(midPoint)
+	a := c.(*component.Association)
+
+	g0, _ := d.componentsContainer.SearchGadget(gadPoint0)
+	g1, _ := d.componentsContainer.SearchGadget(gadPoint1)
+	g2, _ := d.componentsContainer.SearchGadget(gadPoint2)
+	t.Run("set parent start", func(t *testing.T) {
+		err := d.SetParentStartComponent(gadPoint2)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if a.GetParentStart() != g2 {
+			t.Errorf("set parent start fails")
+		}
+		err = d.Undo()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if a.GetParentStart() != g0 {
+			t.Errorf("undo set parent start fails")
+		}
+		err = d.Redo()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if a.GetParentStart() != g2 {
+			t.Errorf("undi set parent start fails")
+		}
+	})
+
+	t.Run("set parent end", func(t *testing.T) {
+		err := d.SetParentEndComponent(gadPoint2)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if a.GetParentStart() != g2 {
+			t.Errorf("set parent start fails")
+		}
+		err = d.Undo()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if a.GetParentStart() != g1 {
+			t.Errorf("undo set parent start fails")
+		}
+		err = d.Redo()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if a.GetParentStart() != g2 {
+			t.Errorf("undi set parent start fails")
+		}
+	})
+}

--- a/app/backend/umldiagram/umldiagram_test.go
+++ b/app/backend/umldiagram/umldiagram_test.go
@@ -1669,3 +1669,133 @@ func CMD_SET_ATTR_ASS(t *testing.T) {
 		}
 	})
 }
+
+func CMD_ADD_REMOVE_ATTR_GAD(t *testing.T) {
+	d, _ := CreateEmptyUMLDiagram("test.uml", ClassDiagram)
+
+	gadPoint0 := utils.Point{X: 0, Y: 0}
+	header0 := "test gadget0"
+	d.AddGadget(component.Class, gadPoint0, 0, drawdata.DefaultGadgetColor, header0)
+	d.SelectComponent(gadPoint0)
+
+	g, _ := d.componentsContainer.SearchGadget(gadPoint0)
+	section := 1
+	t.Run("add attribute", func(t *testing.T) {
+		err := d.AddAttributeToGadget(section, "ඞ")
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if g.GetAttributesLen()[section] != 1 {
+			t.Errorf("add attr to gad fail")
+		}
+		err = d.Undo()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if g.GetAttributesLen()[section] != 0 {
+			t.Errorf("undo add attr to gad fail")
+		}
+		err = d.Redo()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if g.GetAttributesLen()[section] != 1 {
+			t.Errorf("undo add attr to gad fail")
+		}
+	})
+
+	t.Run("remove attribute", func(t *testing.T) {
+		err := d.RemoveAttributeFromGadget(section, 0)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if g.GetAttributesLen()[section] != 0 {
+			t.Errorf("remove attr to gad fail")
+		}
+		err = d.Undo()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if g.GetAttributesLen()[section] != 1 {
+			t.Errorf("undo remove attr to gad fail")
+		}
+		err = d.Redo()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if g.GetAttributesLen()[section] != 0 {
+			t.Errorf("undo remove attr to gad fail")
+		}
+	})
+}
+
+func CMD_ADD_REMOVE_ATTR_ASS(t *testing.T) {
+	d, _ := CreateEmptyUMLDiagram("test.uml", ClassDiagram)
+
+	gadPoint0 := utils.Point{X: 0, Y: 0}
+	gadPoint1 := utils.Point{X: 200, Y: 200}
+	header0 := "test gadget0"
+	header1 := "test gadget1"
+	d.AddGadget(component.Class, gadPoint0, 0, drawdata.DefaultGadgetColor, header0)
+	d.AddGadget(component.Class, gadPoint1, 0, drawdata.DefaultGadgetColor, header1)
+
+	assType0 := component.Composition
+	d.StartAddAssociation(gadPoint0)
+	d.EndAddAssociation(component.AssociationType(assType0), gadPoint1)
+
+	midPoint := utils.Point{
+		X: (gadPoint0.X + gadPoint1.X) / 2,
+		Y: (gadPoint0.Y + gadPoint1.Y) / 2,
+	}
+	d.SelectComponent(midPoint)
+	c, _ := d.componentsContainer.Search(midPoint)
+	a := c.(*component.Association)
+
+	t.Run("add attribute", func(t *testing.T) {
+		err := d.AddAttributeToAssociation(0.5, "ඞ")
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if a.GetAttributesLen() != 1 {
+			t.Errorf("add attr to ass fail")
+		}
+		err = d.Undo()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if a.GetAttributesLen() != 0 {
+			t.Errorf("undo add attr to ass fail")
+		}
+		err = d.Redo()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if a.GetAttributesLen() != 1 {
+			t.Errorf("undo add attr to ass fail")
+		}
+	})
+
+	t.Run("remove attribute", func(t *testing.T) {
+		err := d.RemoveAttributeFromAssociation(0)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if a.GetAttributesLen() != 0 {
+			t.Errorf("remove attr to ass fail")
+		}
+		err = d.Undo()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if a.GetAttributesLen() != 1 {
+			t.Errorf("undo remove attr to ass fail")
+		}
+		err = d.Redo()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if a.GetAttributesLen() != 0 {
+			t.Errorf("undo remove attr to ass fail")
+		}
+	})
+}

--- a/app/backend/umldiagram/umldiagram_test.go
+++ b/app/backend/umldiagram/umldiagram_test.go
@@ -1423,3 +1423,249 @@ func CMD_SET_PARENT(t *testing.T) {
 		}
 	})
 }
+
+func CMD_SET_ATTR_GAD(t *testing.T) {
+	d, _ := CreateEmptyUMLDiagram("test.uml", ClassDiagram)
+
+	gadPoint0 := utils.Point{X: 0, Y: 0}
+	header0 := "test gadget0"
+	d.AddGadget(component.Class, gadPoint0, 0, drawdata.DefaultGadgetColor, header0)
+	d.SelectComponent(gadPoint0)
+
+	g, _ := d.componentsContainer.SearchGadget(gadPoint0)
+
+	t.Run("set content", func(t *testing.T) {
+		getValue := func(g *component.Gadget) string {
+			return g.GetDrawData().(drawdata.Gadget).Attributes[0][0].Content
+		}
+		newValue := "new content"
+		oldValue := getValue(g)
+
+		err := d.SetAttrContentComponent(0, 0, newValue)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if getValue(g) != newValue {
+			t.Errorf("unexpected value: %v, got %v", newValue, getValue(g))
+		}
+		err = d.Undo()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if getValue(g) != oldValue {
+			t.Errorf("unexpected value: %v, got %v", oldValue, getValue(g))
+		}
+		err = d.Redo()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if getValue(g) != newValue {
+			t.Errorf("unexpected value: %v, got %v", oldValue, getValue(g))
+		}
+	})
+
+	t.Run("set size", func(t *testing.T) {
+		getValue := func(g *component.Gadget) int {
+			return g.GetDrawData().(drawdata.Gadget).Attributes[0][0].FontSize
+		}
+		newValue := 69
+		oldValue := getValue(g)
+
+		err := d.SetAttrSizeComponent(0, 0, newValue)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if getValue(g) != newValue {
+			t.Errorf("unexpected value: %v, got %v", newValue, getValue(g))
+		}
+		err = d.Undo()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if getValue(g) != oldValue {
+			t.Errorf("unexpected value: %v, got %v", oldValue, getValue(g))
+		}
+		err = d.Redo()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if getValue(g) != newValue {
+			t.Errorf("unexpected value: %v, got %v", oldValue, getValue(g))
+		}
+	})
+
+	t.Run("set style", func(t *testing.T) {
+		getValue := func(g *component.Gadget) int {
+			return g.GetDrawData().(drawdata.Gadget).Attributes[0][0].FontStyle
+		}
+		newValue := attribute.Bold
+		oldValue := getValue(g)
+
+		err := d.SetAttrStyleComponent(0, 0, newValue)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if getValue(g) != newValue {
+			t.Errorf("unexpected value: %v, got %v", newValue, getValue(g))
+		}
+		err = d.Undo()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if getValue(g) != oldValue {
+			t.Errorf("unexpected value: %v, got %v", oldValue, getValue(g))
+		}
+		err = d.Redo()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if getValue(g) != newValue {
+			t.Errorf("unexpected value: %v, got %v", oldValue, getValue(g))
+		}
+	})
+}
+
+func CMD_SET_ATTR_ASS(t *testing.T) {
+	d, _ := CreateEmptyUMLDiagram("test.uml", ClassDiagram)
+
+	gadPoint0 := utils.Point{X: 0, Y: 0}
+	gadPoint1 := utils.Point{X: 200, Y: 200}
+	header0 := "test gadget0"
+	header1 := "test gadget1"
+	d.AddGadget(component.Class, gadPoint0, 0, drawdata.DefaultGadgetColor, header0)
+	d.AddGadget(component.Class, gadPoint1, 0, drawdata.DefaultGadgetColor, header1)
+
+	assType0 := component.Composition
+	d.StartAddAssociation(gadPoint0)
+	d.EndAddAssociation(component.AssociationType(assType0), gadPoint1)
+
+	midPoint := utils.Point{
+		X: (gadPoint0.X + gadPoint1.X) / 2,
+		Y: (gadPoint0.Y + gadPoint1.Y) / 2,
+	}
+	d.SelectComponent(midPoint)
+	c, _ := d.componentsContainer.Search(midPoint)
+	a := c.(*component.Association)
+
+	d.AddAttributeToAssociation(0.5, "test")
+
+	t.Run("set content", func(t *testing.T) {
+		getValue := func(a *component.Association) string {
+			return a.GetDrawData().(drawdata.Association).Attributes[0].Content
+		}
+		newValue := "new content"
+		oldValue := getValue(a)
+
+		err := d.SetAttrContentComponent(0, 0, newValue)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if getValue(a) != newValue {
+			t.Errorf("unexpected value: %v, got %v", newValue, getValue(a))
+		}
+		err = d.Undo()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if getValue(a) != oldValue {
+			t.Errorf("unexpected value: %v, got %v", oldValue, getValue(a))
+		}
+		err = d.Redo()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if getValue(a) != newValue {
+			t.Errorf("unexpected value: %v, got %v", oldValue, getValue(a))
+		}
+	})
+
+	t.Run("set size", func(t *testing.T) {
+		getValue := func(a *component.Association) int {
+			return a.GetDrawData().(drawdata.Association).Attributes[0].FontSize
+		}
+		newValue := 69
+		oldValue := getValue(a)
+
+		err := d.SetAttrSizeComponent(0, 0, newValue)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if getValue(a) != newValue {
+			t.Errorf("unexpected value: %v, got %v", newValue, getValue(a))
+		}
+		err = d.Undo()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if getValue(a) != oldValue {
+			t.Errorf("unexpected value: %v, got %v", oldValue, getValue(a))
+		}
+		err = d.Redo()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if getValue(a) != newValue {
+			t.Errorf("unexpected value: %v, got %v", oldValue, getValue(a))
+		}
+	})
+
+	t.Run("set style", func(t *testing.T) {
+		getValue := func(a *component.Association) int {
+			return a.GetDrawData().(drawdata.Association).Attributes[0].FontStyle
+		}
+		newValue := attribute.Bold
+		oldValue := getValue(a)
+
+		err := d.SetAttrStyleComponent(0, 0, newValue)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if getValue(a) != newValue {
+			t.Errorf("unexpected value: %v, got %v", newValue, getValue(a))
+		}
+		err = d.Undo()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if getValue(a) != oldValue {
+			t.Errorf("unexpected value: %v, got %v", oldValue, getValue(a))
+		}
+		err = d.Redo()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if getValue(a) != newValue {
+			t.Errorf("unexpected value: %v, got %v", oldValue, getValue(a))
+		}
+	})
+
+	t.Run("set ratio", func(t *testing.T) {
+		getValue := func(a *component.Association) float64 {
+			return a.GetDrawData().(drawdata.Association).Attributes[0].Ratio
+		}
+		newValue := 0.69
+		oldValue := getValue(a)
+
+		err := d.SetAttrRatioComponent(0, 0, newValue)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if getValue(a) != newValue {
+			t.Errorf("unexpected value: %v, got %v", newValue, getValue(a))
+		}
+		err = d.Undo()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if getValue(a) != oldValue {
+			t.Errorf("unexpected value: %v, got %v", oldValue, getValue(a))
+		}
+		err = d.Redo()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if getValue(a) != newValue {
+			t.Errorf("unexpected value: %v, got %v", oldValue, getValue(a))
+		}
+	})
+}

--- a/app/backend/umldiagram/umldiagram_test.go
+++ b/app/backend/umldiagram/umldiagram_test.go
@@ -753,9 +753,7 @@ func TestUMLDiagram_loadAssAttributes(t *testing.T) {
 	assert.NoError(t, errRet)
 	assert.Equal(t, 0, idx)
 
-	atts, err := ass.GetAttributes()
-	assert.NoError(t, err)
-
+	atts := ass.GetAttributes()
 	for i, att := range atts {
 		assert.Equal(t, expectedContent, att.GetContent())
 		assert.Equal(t, expectedStyle, int(att.GetStyle()))

--- a/app/backend/umlproject/umlproject.go
+++ b/app/backend/umlproject/umlproject.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/labstack/gommon/log"
 	"maps"
 	"os"
 	"slices"
 	"time"
+
+	"github.com/labstack/gommon/log"
 
 	"Dr.uml/backend/component"
 	"Dr.uml/backend/drawdata"
@@ -242,6 +243,28 @@ func (p *UMLProject) CloseDiagram(diagramName string) duerror.DUError {
 
 func (p *UMLProject) DeleteDiagram(diagramName string) duerror.DUError {
 	// TODO: remove the file
+	return nil
+}
+
+func (p *UMLProject) UndoDiagramChange() duerror.DUError {
+	if p.currentDiagram == nil {
+		return duerror.NewInvalidArgumentError("No current diagram selected")
+	}
+	if err := p.currentDiagram.Undo(); err != nil {
+		return nil
+	}
+	p.lastModified = time.Now()
+	return nil
+}
+
+func (p *UMLProject) RedoDiagramChange() duerror.DUError {
+	if p.currentDiagram == nil {
+		return duerror.NewInvalidArgumentError("No current diagram selected")
+	}
+	if err := p.currentDiagram.Redo(); err != nil {
+		return nil
+	}
+	p.lastModified = time.Now()
 	return nil
 }
 

--- a/app/backend/umlproject/umlproject.go
+++ b/app/backend/umlproject/umlproject.go
@@ -1,20 +1,21 @@
 package umlproject
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"maps"
+	"os"
+	"slices"
+	"time"
+
 	"Dr.uml/backend/component"
 	"Dr.uml/backend/drawdata"
 	"Dr.uml/backend/umldiagram"
 	"Dr.uml/backend/utils"
 	"Dr.uml/backend/utils/duerror"
-	"context"
-	"encoding/json"
-	"fmt"
 	"github.com/titanous/json5"
 	"github.com/wailsapp/wails/v2/pkg/runtime"
-	"maps"
-	"os"
-	"slices"
-	"time"
 )
 
 type UMLProject struct {
@@ -146,6 +147,17 @@ func (p *UMLProject) SetAttrFontComponent(section int, index int, font string) d
 		return duerror.NewInvalidArgumentError("No current diagram selected")
 	}
 	if err := p.currentDiagram.SetAttrFontComponent(section, index, font); err != nil {
+		return err
+	}
+	p.lastModified = time.Now()
+	return nil
+}
+
+func (p *UMLProject) SetAttrRatioComponent(section int, index int, ratio float64) duerror.DUError {
+	if p.currentDiagram == nil {
+		return duerror.NewInvalidArgumentError("No current diagram selected")
+	}
+	if err := p.currentDiagram.SetAttrRatioComponent(section, index, ratio); err != nil {
 		return err
 	}
 	p.lastModified = time.Now()


### PR DESCRIPTION

## Cmd Pattern Implementation
- Manager class
  - undo, redo stacks containing commands
  - call command execute, unexcute
  - record last modified time
- Command interface
- Various Commands
  - implement command interface
  - for most commands, storing the arguments that are used in execute or unexecute
 <br/>

- ⁉️ Why make commands call diagram's single-line method, instead of defining the method in the command?
  - in command pattern, command should tell reciever to do something, not doing the thing itself.
  - in other words, reciever class hold the responsiblility
  
 ## Change logic in diagram methods
Change logic of many methods in diagram to make them less "command-pattern-hard"
These methods include: add comp, select comp, remove select comp, comp setter, comp attr setter.

For example, the ``AddGadget(point)`` originally doing all the things in the function, now it looks like:
```
func AddGadget(point) {
  g := createGadget(point)
  addGadget(g)
}
```
The ``addGadget(g)`` simply records the gadget in the diagiam.
By separating creating and recording, the command of  AddGadget(point) can record the exact gadget that is being added to diagram. 
This way, redoing/undoing this command only need to add/remove the exact gadget, instead of creating and finding where it is everytime.

## Remove Unused diagram method
Remove the diagram methods that are not being referenced elsewhere other than in test.
These are:
- UnSelectAll


